### PR TITLE
FO-465 & FO-470 Add Wasm Bindings for ABAR transfer & Wasm bindings for Key Generation of type AXFR keypair

### DIFF
--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -70,6 +70,7 @@ use zei::{
         },
     },
 };
+use zei::anon_xfr::structs::{AXfrBody};
 use zeialgebra::jubjub::JubjubScalar;
 
 macro_rules! no_transfer_err {
@@ -1134,6 +1135,114 @@ impl TransferOperationBuilder {
             }
         }
         Ok(self)
+    }
+}
+
+/// AnonTransferOperationBuilder builders anon transfer operation using the factory pattern.
+/// This is used for the wasm interface in building a multi-input/output anon transfer operation.
+pub struct AnonTransferOperationBuilder {
+    inputs: Vec<OpenAnonBlindAssetRecord>,
+    outputs: Vec<OpenAnonBlindAssetRecord>,
+    keypairs: Vec<AXfrKeyPair>,
+
+    body: Option<AXfrBody>,
+    diversified_keypairs: Vec<AXfrKeyPair>,
+    randomizers: Vec<JubjubScalar>,
+    note: Option<AXfrNote>,
+}
+
+impl AnonTransferOperationBuilder {
+
+    /// new returns a fresh default builder
+    pub fn new() -> Self {
+        AnonTransferOperationBuilder{
+            inputs: vec![],
+            outputs: vec![],
+            keypairs: vec![],
+            body: None,
+            diversified_keypairs: vec![],
+            randomizers: vec![],
+            note: None
+        }
+    }
+
+    /// add_input is used for adding an input source to the Anon Transfer Operation factory, it takes
+    /// an ABAR and a Keypair as input
+    pub fn add_input(
+        &mut self,
+        abar: OpenAnonBlindAssetRecord,
+        secret_key: AXfrKeyPair
+    ) -> &mut Self {
+        self.inputs.push(abar);
+        self.keypairs.push(secret_key);
+        self
+    }
+
+    /// add_output is used to add a output record to the Anon Transfer factory
+    pub fn add_output(
+        &mut self,
+        abar: OpenAnonBlindAssetRecord
+    ) -> &mut Self {
+        let randomizer = abar.get_key_rand_factor().clone();
+        self.outputs.push(abar);
+        self.randomizers.push(randomizer);
+        self
+    }
+
+    /// get_randomizers fetches the randomizers for the different outputs.
+    pub fn get_randomizers(&self) -> Vec<JubjubScalar> {
+        self.randomizers.clone()
+    }
+
+    /// build generates the anon transfer body with the Zero Knowledge Proof.
+    pub fn build(&mut self) -> &mut Self {
+        let mut prng = ChaChaRng::from_entropy();
+        let user_params = UserParams::from_file_if_exists(
+            self.inputs.len(),
+            self.outputs.len(),
+            Some(41),
+            DEFAULT_BP_NUM_GENS,
+            None,
+        ).unwrap();
+
+        let (body, diversified_keypairs) = gen_anon_xfr_body(
+            &mut prng,
+            &user_params,
+            self.inputs.as_slice(),
+            self.outputs.as_slice(),
+            self.keypairs.as_slice()
+        ).unwrap();
+
+        self.body = Some(body);
+        self.diversified_keypairs = diversified_keypairs;
+
+        self
+    }
+
+    /// sign method signs the anon transfer body and creates a anon-note for the operation
+    pub fn sign(&mut self) -> &mut Self {
+
+        self.note = Some(
+            AXfrNote::generate_note_from_body(
+                self.body.as_ref().unwrap().clone(),
+                self.diversified_keypairs.clone(),
+            ).unwrap()
+        );
+
+        self
+    }
+
+    /// transaction method wraps the anon transfer note in an Operation and returns it
+    pub fn transaction(&self, nonce: NoReplayToken) -> Result<Operation> {
+        if self.note.is_none() {
+            return Err(eg!("Anon transfer not built and signed"));
+        }
+
+        Ok(Operation::TransferAnonAsset(
+            Box::from(
+                AnonTransferOps::new(self.note.as_ref().unwrap().clone(), nonce).unwrap()
+            )
+        ))
     }
 }
 

--- a/src/components/wasm/Cargo.toml
+++ b/src/components/wasm/Cargo.toml
@@ -37,6 +37,7 @@ getrandom = { version = "0.2", features = ["js"] }
 
 zei = { git = "https://@github.com/FindoraNetwork/zei", branch = "develop" }
 ruc = "0.6.2"
+algebra = { package = "algebra", git = "https://github.com/FindoraNetwork/zei", branch = "develop" }
 crypto = { package = "crypto", git = "https://github.com/FindoraNetwork/zei", branch = "develop" }
 
 finutils = { path = "../finutils", default-features = false }

--- a/src/components/wasm/src/wasm.rs
+++ b/src/components/wasm/src/wasm.rs
@@ -1099,6 +1099,12 @@ impl AnonTransferOperationBuilder {
     }
 
     /// add_input is used to add a new input source for Anon Transfer
+    /// @param {AnonBlindAssetRecord} abar - input ABAR to transfer
+    /// @param {OwnerMemo} memo - memo corresponding to the input abar
+    /// @param keypair {AXfrKeyPair} - AXfrKeyPair of the ABAR owner
+    /// @param dec_key {XSecretKey} - Decryption key of the abar owner to open the Owner Memo
+    /// @param MTLeafInfo {mt_leaf_info} - the Merkle proof of the ABAR from commitment tree
+    /// @throws Will throw an error if abar fails to open, input fails to get added to Operation
     pub fn add_input(
         mut self,
         abar: AnonBlindAssetRecord,
@@ -1126,6 +1132,10 @@ impl AnonTransferOperationBuilder {
     }
 
     /// add_output is used to add a output to the Anon Transfer
+    /// @param amount {u64} - amount to be sent to the receiver
+    /// @param to {AXfrPubKey} - original pub key of receiver
+    /// @param to_enc_key {XPublicKey} - The encryption public key of receiver.
+    /// @throws error if ABAR fails to be built
     pub fn add_output(
         mut self,
         amount: u64,
@@ -1150,12 +1160,12 @@ impl AnonTransferOperationBuilder {
         Ok(self)
     }
 
-    /// get_randomizers
+    /// get_randomizers returns a list of all the randomizers for receiver public keys
     pub fn get_randomizers(&self) -> Vec<JubjubScalar> {
         self.get_builder().get_randomizers()
     }
 
-    /// create is used to buiuld proof and sign the Transfer Operation
+    /// create is used to build proof and sign the Transfer Operation
     pub fn create(mut self) -> Result<AnonTransferOperationBuilder, JsValue> {
         self.get_builder_mut()
             .build()
@@ -1171,6 +1181,7 @@ impl AnonTransferOperationBuilder {
     }
 
     /// transaction returns the prepared Anon Transfer Operation
+    /// @param nonce {NoReplayToken} - nonce of the txn to be added to the operation
     pub fn transaction(self, nonce: NoReplayToken) -> Result<String, JsValue> {
         let op = self
             .get_builder()


### PR DESCRIPTION
		for Key Generation of type AXFR keypair

1. Added wasm interface for generating random anon keypairs
2. Wasm Interface for factory pattern of Anon Transfer builder

* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**



* **Extra documentations**


