### PR TITLE
Fixing issue with contract deployment. 

### DIFF
--- a/src/components/contracts/modules/evm/src/impls.rs
+++ b/src/components/contracts/modules/evm/src/impls.rs
@@ -32,8 +32,7 @@ impl<C: Config> App<C> {
         if code.is_empty() {
             return Ok(());
         }
-
-        AccountCodes::insert(ctx.state.write().borrow_mut(), &address, &code)
+        AccountCodes::insert_bytes(ctx.state.write().borrow_mut(), &address, code)
     }
 
     /// Get the account code
@@ -43,8 +42,10 @@ impl<C: Config> App<C> {
         height: Option<u64>,
     ) -> Option<Vec<u8>> {
         match height {
-            Some(ver) => AccountCodes::get_ver(ctx.state.read().borrow(), address, ver),
-            None => AccountCodes::get(ctx.state.read().borrow(), address),
+            Some(ver) => {
+                AccountCodes::get_ver_bytes(ctx.state.read().borrow(), address, ver)
+            }
+            None => AccountCodes::get_bytes(ctx.state.read().borrow(), address),
         }
     }
 

--- a/src/components/contracts/primitives/storage/src/types/map.rs
+++ b/src/components/contracts/primitives/storage/src/types/map.rs
@@ -70,6 +70,11 @@ where
             .unwrap()
     }
 
+    /// Load the value associated with the given key from the map.
+    pub fn get_bytes<D: MerkleDB>(state: &State<D>, key: &Key) -> Option<Vec<u8>> {
+        Instance::get::<D>(state, Self::build_key_for(key).as_slice()).unwrap()
+    }
+
     /// Load versioned value associated with the given key from the map.
     pub fn get_ver<D: MerkleDB>(
         state: &State<D>,
@@ -82,6 +87,15 @@ where
             height,
         )
         .unwrap()
+    }
+
+    /// Load versioned value associated with the given key from the map.
+    pub fn get_ver_bytes<D: MerkleDB>(
+        state: &State<D>,
+        key: &Key,
+        height: u64,
+    ) -> Option<Vec<u8>> {
+        Instance::get_v::<D>(state, Self::build_key_for(key).as_slice(), height).unwrap()
     }
 
     /// Load the unique key value pair with specified prefix.
@@ -113,6 +127,15 @@ where
         val: &Value,
     ) -> Result<()> {
         Instance::set_obj::<Value, D>(state, Self::build_key_for(key).as_slice(), val)
+    }
+
+    /// Store a serialized value to be associated with the given key from the map.
+    pub fn insert_bytes<D: MerkleDB>(
+        state: &mut State<D>,
+        key: &Key,
+        val: Vec<u8>,
+    ) -> Result<()> {
+        Instance::set::<D>(state, Self::build_key_for(key).as_slice(), val)
     }
 
     /// Remove the value under a key.


### PR DESCRIPTION
Prior to the change, the code was being serialized before persisted to the db. Now the code is written directly to the db as raw bytes.

