### PR TITLE
FO-704: Transaction index data migration from state to db

### DIFF
--- a/src/components/contracts/modules/ethereum/Cargo.toml
+++ b/src/components/contracts/modules/ethereum/Cargo.toml
@@ -34,6 +34,7 @@ fp-utils = { path = "../../primitives/utils" }
 baseapp = { path = "../../baseapp" }
 fp-mocks = { path = "../../primitives/mocks" }
 module-account = { path = "../account" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.1.3" }
 
 [features]
 default = []

--- a/src/components/contracts/modules/ethereum/src/impls.rs
+++ b/src/components/contracts/modules/ethereum/src/impls.rs
@@ -419,13 +419,14 @@ impl<C: Config> App<C> {
         None
     }
 
-    pub fn migrate(ctx: Context) -> Result<()> {
+    pub fn migrate(ctx: &mut Context) -> Result<()> {
         //Migrate existing transaction indices from chain-state to rocksdb.
         let txn_idxs: Vec<(HA256, (U256, u32))> =
             TransactionIndex::iterate(ctx.state.read().borrow());
         for idx in txn_idxs {
             TransactionIndex::insert(ctx.db.write().borrow_mut(), &idx.0, &idx.1)?;
         }
+        ctx.db.write().commit_session();
         Ok(())
     }
 }

--- a/src/components/contracts/modules/ethereum/src/impls.rs
+++ b/src/components/contracts/modules/ethereum/src/impls.rs
@@ -423,10 +423,15 @@ impl<C: Config> App<C> {
         //Migrate existing transaction indices from chain-state to rocksdb.
         let txn_idxs: Vec<(HA256, (U256, u32))> =
             TransactionIndex::iterate(ctx.state.read().borrow());
+        let txn_idxs_cnt = txn_idxs.len();
+
         for idx in txn_idxs {
             TransactionIndex::insert(ctx.db.write().borrow_mut(), &idx.0, &idx.1)?;
+            debug!(target: "ethereum", "hash: 0x{}, block: {}, index: {}", idx.0.to_string(), idx.1 .0, idx.1 .1);
         }
         ctx.db.write().commit_session();
+        info!(target: "ethereum", "{} transaction indexes migrated to db", txn_idxs_cnt);
+
         Ok(())
     }
 }

--- a/src/components/contracts/modules/ethereum/src/impls.rs
+++ b/src/components/contracts/modules/ethereum/src/impls.rs
@@ -418,4 +418,14 @@ impl<C: Config> App<C> {
         }
         None
     }
+
+    pub fn migrate(ctx: Context) -> Result<()> {
+        //Migrate existing transaction indices from chain-state to rocksdb.
+        let txn_idxs: Vec<(HA256, (U256, u32))> =
+            TransactionIndex::iterate(ctx.state.read().borrow());
+        for idx in txn_idxs {
+            TransactionIndex::insert(ctx.db.write().borrow_mut(), &idx.0, &idx.1)?;
+        }
+        Ok(())
+    }
 }

--- a/src/components/contracts/modules/ethereum/tests/ethereum_db.rs
+++ b/src/components/contracts/modules/ethereum/tests/ethereum_db.rs
@@ -42,7 +42,7 @@ fn setup() -> Context {
 
 #[test]
 fn test_eth_db_migrate_txn_index() {
-    let ctx = setup();
+    let mut ctx = setup();
 
     //Create txn hashes, block numbers and indices and save them to chain-state
     let mut txns = Vec::with_capacity(5);
@@ -63,19 +63,19 @@ fn test_eth_db_migrate_txn_index() {
         //Save Transaction index
         txns.push((HA256::new(transaction_hash), (U256::from(i), i)));
         let _ = TransactionIndex::insert(
-            ctx.clone().state.write().borrow_mut(),
+            ctx.state.write().borrow_mut(),
             &HA256::new(transaction_hash),
             &(U256::from(i), i),
         );
     }
 
     //Call migrate on ethereum module.
-    let _ = module_ethereum::App::<BaseApp>::migrate(ctx.clone());
+    let _ = module_ethereum::App::<BaseApp>::migrate(ctx.borrow_mut());
 
     //Confirm transaction index values were migrated to rocksdb instance from the context.
     for txn in txns {
         let value: Option<(U256, u32)> =
-            TransactionIndex::get(ctx.clone().db.read().borrow(), &txn.0);
+            TransactionIndex::get(ctx.db.read().borrow(), &txn.0);
         assert!(value.is_some());
         assert_eq!(value.unwrap(), txn.1);
     }

--- a/src/components/contracts/modules/ethereum/tests/ethereum_db.rs
+++ b/src/components/contracts/modules/ethereum/tests/ethereum_db.rs
@@ -1,0 +1,82 @@
+use baseapp::BaseApp;
+use ethereum::{TransactionAction, TransactionSignature, TransactionV0};
+use fp_core::context::Context;
+use fp_storage::{Borrow, BorrowMut, RwLock};
+use fp_types::crypto::HA256;
+use fp_types::{H256, U256};
+use module_ethereum::storage::TransactionIndex;
+use sha3::{Digest, Keccak256};
+use std::env::temp_dir;
+use std::sync::Arc;
+use std::time::SystemTime;
+use storage::db::{FinDB, RocksDB};
+use storage::state::ChainState;
+
+fn setup() -> Context {
+    let time = SystemTime::now()
+        .duration_since(SystemTime::UNIX_EPOCH)
+        .unwrap()
+        .as_nanos();
+    let mut path = temp_dir();
+    path.push(format!("temp-findora-db–{}", time));
+
+    let fdb = FinDB::open(path).unwrap();
+    let chain_state = Arc::new(RwLock::new(ChainState::new(
+        fdb,
+        "temp_db".to_string(),
+        100,
+    )));
+
+    let mut rocks_path = temp_dir();
+    rocks_path.push(format!("temp-rocks-db–{}", time));
+
+    let rdb = RocksDB::open(rocks_path).unwrap();
+    let chain_db = Arc::new(RwLock::new(ChainState::new(
+        rdb,
+        "temp_rocks_db".to_string(),
+        0,
+    )));
+
+    Context::new(chain_state, chain_db)
+}
+
+#[test]
+fn test_eth_db_migrate_txn_index() {
+    let ctx = setup();
+
+    //Create txn hashes, block numbers and indices and save them to chain-state
+    let mut txns = Vec::with_capacity(5);
+    for i in 0..5 {
+        let txn = TransactionV0 {
+            nonce: U256::from(i),
+            gas_price: Default::default(),
+            gas_limit: Default::default(),
+            action: TransactionAction::Create,
+            value: Default::default(),
+            input: vec![],
+            signature: TransactionSignature::new(27, H256::random(), H256::random())
+                .unwrap(),
+        };
+
+        let transaction_hash =
+            H256::from_slice(Keccak256::digest(&rlp::encode(&txn)).as_slice());
+        //Save Transaction index
+        txns.push((HA256::new(transaction_hash), (U256::from(i), i)));
+        let _ = TransactionIndex::insert(
+            ctx.clone().state.write().borrow_mut(),
+            &HA256::new(transaction_hash),
+            &(U256::from(i), i),
+        );
+    }
+
+    //Call migrate on ethereum module.
+    let _ = module_ethereum::App::<BaseApp>::migrate(ctx.clone());
+
+    //Confirm transaction index values were migrated to rocksdb instance from the context.
+    for txn in txns {
+        let value: Option<(U256, u32)> =
+            TransactionIndex::get(ctx.clone().db.read().borrow(), &txn.0);
+        assert!(value.is_some());
+        assert_eq!(value.unwrap(), txn.1);
+    }
+}


### PR DESCRIPTION
Background: Mainnet mistakingly writes TransactionIndex into chain state which shouldn't be reverted regardless of failure of transactions.

* Fetch all existing TransactionIndex data from chain state and write them into chain db when node starts up.


