### PR TITLE
Fix misbehavior of delegating.

### DIFF
--- a/src/ledger/src/staking/mod.rs
+++ b/src/ledger/src/staking/mod.rs
@@ -29,6 +29,7 @@ use {
     config::abci::global_cfg::CFG,
     cosig::CoSigRule,
     cryptohash::sha256::{self, Digest},
+    curve25519_dalek::{edwards::EdwardsPoint, scalar::Scalar, traits::Identity},
     fbnc::{new_mapx, Mapx},
     globutils::wallet,
     indexmap::IndexMap,
@@ -103,11 +104,15 @@ lazy_static! {
     ///A hard-coded key for "blacklist", that blacklist delegate a validator means nobody can delegate it.
     pub static ref  LOCK_KEY: XfrPublicKey = {
         let bytes : [u8;32]=[
-            8,  8, 8,   8, 8, 8,  8, 8, 88,  8, 8, 8, 8, 8,   8,  8,
-            8, 8, 8, 8, 8, 8,  8,  8, 8,   8,  8, 8, 8,   8,   8, 8
+            8,  8, 8,  8, 8, 88,  8, 8, 8,  8, 8, 88, 8, 8,   8,  8,
+            8, 88, 8, 8, 8, 8,  8,  8, 8,  8,  8, 8, 8,   88,   8, 8
         ];
 
-        XfrPublicKey::zei_from_bytes(&bytes).unwrap()
+        let scalar = Scalar::from_bits(bytes);
+        let point = EdwardsPoint::identity() * scalar;
+        let compressed_y = point.compress();
+
+        XfrPublicKey::zei_from_bytes(compressed_y.as_bytes()).unwrap()
     };
 }
 


### PR DESCRIPTION
Problem: if the the validator unstake itself, the validator's status will be unstake and would be removed from the validator set , but others can delegate 1 to the validator and make it become staked and let it join in set validator set again.

This PR will introduce a lock mechanism to prevent other delegating to a unstaked validator. To achieve this, we make a special delegation from a "lock",  validators the lock delegated to would not be delegated by others.

* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**

   - Hard-code a address(public key) respresenting a "lock", the private key of "lock" is unknow.
   - Check "lock" when in `fn delegate`
   - Check and add  "lock" in `fn undelegate`

* **Extra documentations**


