### PR TITLE
Fix misbehavior of validator's unstaking, eg: issue 197.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,5 @@ seq_id.str
 utxo.map
 
 *.tmp
+
+checkpoint.toml

--- a/src/components/config/src/abci/mod.rs
+++ b/src/components/config/src/abci/mod.rs
@@ -26,6 +26,7 @@ pub struct CheckPointConfig {
     pub ff_addr_extra_fix_height: u64,
     pub nonconfidential_balance_fix_height: u64,
     pub unbond_block_cnt: u64,
+    pub undelegation_fix_height: u64,
 }
 
 impl CheckPointConfig {
@@ -50,6 +51,7 @@ impl CheckPointConfig {
                                 ff_addr_extra_fix_height: 0,
                                 nonconfidential_balance_fix_height: 0,
                                 unbond_block_cnt: 3600 * 24 * 21 / 16,
+                                undelegation_fix_height: 0,
                             };
                             #[cfg(not(feature = "debug_env"))]
                             let config = CheckPointConfig {
@@ -64,6 +66,7 @@ impl CheckPointConfig {
                                 ff_addr_extra_fix_height: 1200000,
                                 nonconfidential_balance_fix_height: 1210000,
                                 unbond_block_cnt: 3600 * 24 * 21 / 16,
+                                undelegation_fix_height: 1501000,
                             };
                             let content = toml::to_string(&config).unwrap();
                             file.write_all(content.as_bytes()).unwrap();

--- a/src/ledger/src/staking/mod.rs
+++ b/src/ledger/src/staking/mod.rs
@@ -29,6 +29,7 @@ use {
     config::abci::global_cfg::CFG,
     cosig::CoSigRule,
     cryptohash::sha256::{self, Digest},
+    curve25519_dalek::{edwards::EdwardsPoint, scalar::Scalar, traits::Identity},
     fbnc::{new_mapx, Mapx},
     globutils::wallet,
     indexmap::IndexMap,
@@ -269,7 +270,12 @@ impl Staking {
                     mask.get_unchecked(i) ^ bytes.get_unchecked(i)
             }
         }
-        XfrPublicKey::zei_from_bytes(&templete).unwrap()
+
+        let scalar = Scalar::from_bits(templete);
+        let point = EdwardsPoint::identity() * scalar;
+        let compressed_y = point.compress();
+
+        XfrPublicKey::zei_from_bytes(compressed_y.as_bytes()).unwrap()
     }
 
     #[inline(always)]


### PR DESCRIPTION
Fix the [issue](https://github.com/FindoraNetwork/platform/issues/197).

This problem arised because the code use a random state to generate a random publick key for undelegation, but it always generate a same key.

* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**

A new "random" public key generation.

Clean paid delegation completely.

Add a height to fix this.


* **Extra documentations**


