### PR TITLE
Integrating anon transfer fee and remainder with txn builder and CLI

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -278,3 +278,7 @@ run_bar_to_abar_demo: devnet
 
 run_anon_transfer_demo: devnet
 	@./tools/triple_masking/anonxfr_test_demo.sh
+
+run_multi_anon_transfer_demo: devnet
+	@./tools/triple_masking/multi_axfr_test_demo.sh
+

--- a/Makefile
+++ b/Makefile
@@ -281,4 +281,3 @@ run_anon_transfer_demo: devnet
 
 run_multi_anon_transfer_demo: devnet
 	@./tools/triple_masking/multi_axfr_test_demo.sh
-

--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -7,6 +7,9 @@
 
 mod amount;
 
+//use crypto::basics::hybrid_encryption::XSecretKey;
+use zei::anon_xfr::config::FEE_CALCULATING_FUNC;
+use zei::anon_xfr::structs::OpenAnonBlindAssetRecordBuilder;
 use {
     credentials::CredUserSecretKey,
     crypto::basics::hybrid_encryption::XPublicKey,
@@ -559,12 +562,24 @@ impl TransactionBuilder {
         &mut self,
         inputs: &[OpenAnonBlindAssetRecord],
         outputs: &[OpenAnonBlindAssetRecord],
-        pub_key: &AXfrPubKey,
+        //pub_key: &AXfrPubKey,
+        input_keypairs: &[AXfrKeyPair],
+        //s_key: XSecretKey,
+        pu_key: XPublicKey,
+    ) -> Result<(&mut Self, AXfrNote)> {
 
-    ) -> Result<(&mut self, &[OpenAnonBlindAssetRecord], &[OpenAnonBlindAssetRecord])> {
-        let list_of_abar = get_owned_abars(pub_key);
+        let mut prng = ChaChaRng::from_entropy();
+        let depth: usize = 41;
+
         let mut sum_input = 0;
         let mut sum_output = 0;
+
+        /*
+        In general we will have that the sum of FRA inputs is going to be greater
+        than output + fees, let's say remainder = inputs - (outputs + fees), the remainder amount
+        is going tobe returned to the sender (the change) whenever the remainder is greater than zero,
+        so in that case we need to add this new output
+        */
 
         for input in inputs
         {
@@ -573,58 +588,61 @@ impl TransactionBuilder {
             }
         }
 
+
         for output in outputs
         {
-            if let ASSET_TYPE_FRA = input.get_asset_type() {
-                sum_output += input.get_amount();
+            if let ASSET_TYPE_FRA = output.get_asset_type() {
+                sum_output += output.get_amount();
             }
         }
 
+        //assert!((sum_input > sum_output).is_okay());
 
-        //Here we add the fees output to the black hole address in the calculation
-        let fees = FEE_CALCULATING_FUNC (inputs.len() as u32, outputs.input_len() as u32 + 1 );
 
-        if sum_input - sum_output == fees {
-            //Create the new output to the black_hole_addres
-            //It means that the fees are paid exactly
-            let output_fees_burt = OpenAnonBlindAssetRecord
+        //Here we add the output to return the change to the sender address in the calculation
+        let mut fees = FEE_CALCULATING_FUNC (inputs.len() as u32, outputs.len() as u32);
+
+        let mut remainder = sum_input as i64 - sum_output as i64 - fees as i64;
+
+        let mut vec_outputs = outputs.to_vec();
+
+        if remainder > 0 {
+
+            fees = FEE_CALCULATING_FUNC (inputs.len() as u32, outputs.len() as u32 + 1);
+
+            remainder = sum_input as i64- sum_output as i64 - fees as i64;
+
+            let oabar_money_back = OpenAnonBlindAssetRecordBuilder::new()
+                .amount(remainder as u64)
+                .asset_type(ASSET_TYPE_FRA)
+                .pub_key(input_keypairs[1].pub_key())
+                .finalize(&mut prng, &pu_key)
+                .unwrap()
+                .build()
+                .unwrap();
+
+            //Add oabar to outputs
+            vec_outputs.push(oabar_money_back);
         }
-        //Thi is the case where inputs is greater than output + fees, so
-        // lets say X = inputs - (outputs + fees)
-        //We need to have two additional outputs one for the fees to the black_hole_address
-        // and one more for X to the sender's address (the change)
-        else {
-            let fees = FEE_CALCULATING_FUNC (inputs.len() as u32, outputs.input_len() as u32 + 2 );
-            //Create out put fees ------> black_hole
-            //Create out X fees ------> sender's address
 
-        }
+        let outputs_2 = &vec_outputs[..];
 
-        OK(self, inputs, outputs)
+        let user_params = UserParams::new(
+            inputs.len(),
+            outputs_2.len(),
+            Option::from(depth),
+        );
 
+        let (body, keypairs) =
+            gen_anon_xfr_body(&mut prng, &user_params, inputs, outputs_2, input_keypairs)
+                .c(d!())?;
+        let note = AXfrNote::generate_note_from_body(body, keypairs).c(d!())?;
+        let inp = AnonTransferOps::new(note.clone(), self.no_replay_token).c(d!())?;
+        let op = Operation::TransferAnonAsset(Box::new(inp));
+        self.txn.add_operation(op);
+        Ok((self, note))
     }
 
-
-    //This function is going to do the same  as the above function but
-    //selecting the best input combination to minimize the change (Minimum Coin Change Problem)
-    pub fn add_operation_auto_fees(
-        &mut self,
-        pub_key: &XfrPublicKey,
-        s_key: &XSecretKey,
-    ) -> Result<(&mut self, &[OpenAnonBlindAssetRecord])>
-    {
-        self.transaction().
-        Okay(self, )
-    }
-
-    pub fn add_operation_non_fra(
-        &mut self,
-        pub_key: &XfrPublicKey,
-        s_key: &XSecretKey,
-    ) -> Result<&mut self>{
-
-        Okay(self)
-    }
 
 
     /// Add a operation to delegating finddra accmount to a tendermint validator.
@@ -1868,6 +1886,114 @@ mod tests {
         assert!(txn_sid_result.is_ok());
         let _txn_sid_result = txn_sid_result.unwrap();
     }
+
+    /*
+    Serge
+     */
+    #[test]
+    //This contains only the positive tests with the fees included
+    fn axfr_create_verify_unit_positive_tests_with_fees_2() {
+        let mut ledger_state = LedgerState::tmp_ledger();
+        let _ledger_status = ledger_state.get_status();
+
+        //let zero = BLSScalar::zero();
+
+        let mut prng = ChaChaRng::from_seed([0u8; 32]);
+
+        let amount = 2000000i64;
+        let amount_nonneg = Amount::from_nonnegative_i64(amount);
+        assert!(amount_nonneg.is_ok());
+
+        //let fee_amount = FEE_CALCULATING_FUNC(2, 1) as i64;
+        let fee_amount = 1000000i64;
+        let fee_amount_nonneg = Amount::from_nonnegative_i64(fee_amount);
+        assert!(fee_amount_nonneg.is_ok());
+
+        //let amount_output = amount + fee_amount;
+        let amount_output = 1000000i64;
+        let amount_output_nonneg = Amount::from_nonnegative_i64(amount_output);
+        assert!(amount_output_nonneg.is_ok());
+
+        //Here the Asset Type is generated as a 32 byte and each of them are zero
+        //let asset_type = AT::from_identical_byte(0);
+        let asset_type = ASSET_TYPE_FRA;
+
+        // simulate input abar
+        let (mut oabar, keypair_in, _dec_key_in, enc_key_in) =
+            gen_oabar_and_keys(&mut prng, amount_nonneg.unwrap(), asset_type);
+
+        // simulate input fee abar
+        let (mut oabar_fee, keypair_in_fee, _dec_key_in, _) =
+            gen_oabar_and_keys(&mut prng, fee_amount_nonneg.unwrap(), asset_type);
+
+        let abar = AnonBlindAssetRecord::from_oabar(&oabar);
+
+        let fee_abar = AnonBlindAssetRecord::from_oabar(&oabar_fee);
+
+        //let asset_type_out = AT::from_identical_byte(0);
+        let asset_type_out = ASSET_TYPE_FRA;
+
+        //Simulate output abar
+        let (oabar_out, _keypair_out, _dec_key_out, _) =
+            gen_oabar_and_keys(&mut prng, amount_output_nonneg.unwrap(), asset_type_out);
+
+        let _abar_out = AnonBlindAssetRecord::from_oabar(&oabar_out);
+
+        let mut builder = TransactionBuilder::from_seq_id(1);
+
+        let _owner_memo = oabar.get_owner_memo().unwrap();
+
+        // add abar to merkle tree
+        let uid = ledger_state.add_abar(&abar).unwrap();
+        let uid_fee = ledger_state.add_abar(&fee_abar).unwrap();
+
+        ledger_state.compute_and_append_txns_hash(&BlockEffect::default());
+        let _ = ledger_state.compute_and_save_state_commitment_data(1);
+        //ledger_state.compute_and_append_txns_hash(&BlockEffect::default());
+
+        //let _ = ledger_state.compute_and_save_state_commitment_data(2);
+
+        let mt_leaf_info = ledger_state.get_abar_proof(uid).unwrap();
+        let mt_leaf_fee_info = ledger_state.get_abar_proof(uid_fee).unwrap();
+
+        // add fee abar to merkle tree
+        oabar.update_mt_leaf_info(mt_leaf_info);
+
+        oabar_fee.update_mt_leaf_info(mt_leaf_fee_info);
+        //let _ = ledger_state.compute_and_save_state_commitment_data(2);
+
+        let vec_inputs = vec![oabar, oabar_fee];
+        let vec_oututs = vec![oabar_out];
+        let vec_keys = vec![keypair_in, keypair_in_fee];
+
+        let result =
+            //builder.add_operation_anon_transfer(&vec_inputs, &vec_oututs, &vec_keys);
+            builder.add_operation_fra_fees(&vec_inputs, &vec_oututs, &vec_keys, enc_key_in);
+
+        //let _r = result.unwrap();
+        assert!(result.is_ok());
+
+        let txn = builder.take_transaction();
+        let compute_effect = TxnEffect::compute_effect(txn).unwrap();
+        let mut block = BlockEffect::default();
+        let block_result = block.add_txn_effect(compute_effect);
+        //let block_result = block.add_txn_effect(compute_effect, true);
+
+        assert!(block_result.is_ok());
+
+        for n in block.new_nullifiers.iter() {
+            let _str = base64::encode_config(&n.to_bytes(), base64::URL_SAFE);
+        }
+        let txn_sid_result = ledger_state.finish_block(block);
+        assert!(txn_sid_result.is_ok());
+        let _txn_sid_result = txn_sid_result.unwrap();
+    }
+
+
+    /*
+    =============================================
+     */
+
 
     //Negative tests added
     #[test]

--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -566,7 +566,7 @@ impl TransactionBuilder {
         /*
         In general we will have that the sum of FRA inputs is going to be greater
         than output + fees, let's say remainder = inputs - (outputs + fees), the remainder amount
-        is going tobe returned to the sender (the change) whenever the remainder is greater than zero,
+        is going to be returned to the sender (the change) whenever the remainder is greater than zero,
         so in that case we need to add this new output
         */
 
@@ -582,7 +582,7 @@ impl TransactionBuilder {
             }
         }
 
-        //Here we add the output to return the change to the sender address in the calculation
+        //Here we add the output to return the change to the sender's address
         let fees = FEE_CALCULATING_FUNC(inputs.len() as u32, outputs.len() as u32 + 1);
 
         let remainder = sum_input as i64 - sum_output as i64 - fees as i64;

--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -544,6 +544,89 @@ impl TransactionBuilder {
         Ok((self, note))
     }
 
+
+    /*
+    1. get_owned_abars
+    2. find input combination with amount + 1 FRA
+    3. calculate fees with ip, op+2
+    4. create output list with receiver op, fee blackhole op, money back op
+    5. create ip list
+    6. call add_operation_anon_transfer with lists & private key
+    */
+
+
+    pub fn add_operation_fra_fees(
+        &mut self,
+        inputs: &[OpenAnonBlindAssetRecord],
+        outputs: &[OpenAnonBlindAssetRecord],
+        pub_key: &AXfrPubKey,
+
+    ) -> Result<(&mut self, &[OpenAnonBlindAssetRecord], &[OpenAnonBlindAssetRecord])> {
+        let list_of_abar = get_owned_abars(pub_key);
+        let mut sum_input = 0;
+        let mut sum_output = 0;
+
+        for input in inputs
+        {
+            if let ASSET_TYPE_FRA = input.get_asset_type() {
+                sum_input += input.get_amount();
+            }
+        }
+
+        for output in outputs
+        {
+            if let ASSET_TYPE_FRA = input.get_asset_type() {
+                sum_output += input.get_amount();
+            }
+        }
+
+
+        //Here we add the fees output to the black hole address in the calculation
+        let fees = FEE_CALCULATING_FUNC (inputs.len() as u32, outputs.input_len() as u32 + 1 );
+
+        if sum_input - sum_output == fees {
+            //Create the new output to the black_hole_addres
+            //It means that the fees are paid exactly
+            let output_fees_burt = OpenAnonBlindAssetRecord
+        }
+        //Thi is the case where inputs is greater than output + fees, so
+        // lets say X = inputs - (outputs + fees)
+        //We need to have two additional outputs one for the fees to the black_hole_address
+        // and one more for X to the sender's address (the change)
+        else {
+            let fees = FEE_CALCULATING_FUNC (inputs.len() as u32, outputs.input_len() as u32 + 2 );
+            //Create out put fees ------> black_hole
+            //Create out X fees ------> sender's address
+
+        }
+
+        OK(self, inputs, outputs)
+
+    }
+
+
+    //This function is going to do the same  as the above function but
+    //selecting the best input combination to minimize the change (Minimum Coin Change Problem)
+    pub fn add_operation_auto_fees(
+        &mut self,
+        pub_key: &XfrPublicKey,
+        s_key: &XSecretKey,
+    ) -> Result<(&mut self, &[OpenAnonBlindAssetRecord])>
+    {
+        self.transaction().
+        Okay(self, )
+    }
+
+    pub fn add_operation_non_fra(
+        &mut self,
+        pub_key: &XfrPublicKey,
+        s_key: &XSecretKey,
+    ) -> Result<&mut self>{
+
+        Okay(self)
+    }
+
+
     /// Add a operation to delegating finddra accmount to a tendermint validator.
     /// The transfer operation to BLACK_HOLE_PUBKEY_STAKING should be sent along with.
     pub fn add_operation_delegation(

--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -7,9 +7,6 @@
 
 mod amount;
 
-//use crypto::basics::hybrid_encryption::XSecretKey;
-use zei::anon_xfr::config::FEE_CALCULATING_FUNC;
-use zei::anon_xfr::structs::OpenAnonBlindAssetRecordBuilder;
 use {
     credentials::CredUserSecretKey,
     crypto::basics::hybrid_encryption::XPublicKey,
@@ -54,9 +51,12 @@ use {
     zei::{
         anon_xfr::{
             bar_to_abar::gen_bar_to_abar_body,
+            config::FEE_CALCULATING_FUNC,
             gen_anon_xfr_body,
             keys::{AXfrKeyPair, AXfrPubKey},
-            structs::{AXfrNote, OpenAnonBlindAssetRecord},
+            structs::{
+                AXfrNote, OpenAnonBlindAssetRecord, OpenAnonBlindAssetRecordBuilder,
+            },
         },
         api::anon_creds::{
             ac_confidential_open_commitment, ACCommitment, ACCommitmentKey,
@@ -1387,7 +1387,7 @@ mod tests {
         rand_chacha::ChaChaRng,
         rand_core::SeedableRng,
         std::ops::Neg,
-        zei::anon_xfr::bar_to_from_abar::verify_bar_to_abar_note,
+        zei::anon_xfr::bar_to_abar::verify_bar_to_abar_note,
         zei::anon_xfr::config::FEE_CALCULATING_FUNC,
         zei::anon_xfr::structs::{
             AnonBlindAssetRecord, OpenAnonBlindAssetRecordBuilder,
@@ -1780,7 +1780,7 @@ mod tests {
             let user_params = UserParams::eq_committed_vals_params();
             let node_params = NodeParams::from(user_params);
             let result =
-                verify_bar_to_abar_note(&node_params, &note.note, from.get_pk_ref(), 0);
+                verify_bar_to_abar_note(&node_params, &note.note, from.get_pk_ref());
             assert!(result.is_ok());
         }
     }

--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -557,7 +557,9 @@ impl TransactionBuilder {
     6. call add_operation_anon_transfer with lists & private key
     */
 
-
+    ///This function works as add_operation_anon_transfer but this implement fees,
+    /// Remainder is computed as remainder = sum_inputs - sum_outputs - fees
+    /// all this related to the asset type for fees which are fixed as FRA asset type
     pub fn add_operation_anon_transfer_fees_remainder(
         &mut self,
         inputs: &[OpenAnonBlindAssetRecord],
@@ -586,7 +588,6 @@ impl TransactionBuilder {
             }
         }
 
-
         for output in outputs
         {
             if let ASSET_TYPE_FRA = output.get_asset_type() {
@@ -594,11 +595,11 @@ impl TransactionBuilder {
             }
         }
 
-
         //Here we add the output to return the change to the sender address in the calculation
         let fees = FEE_CALCULATING_FUNC (inputs.len() as u32, outputs.len() as u32 + 1);
 
         let remainder = sum_input as i64 - sum_output as i64 - fees as i64;
+
 
         let mut vec_outputs = outputs.to_vec();
 
@@ -633,6 +634,7 @@ impl TransactionBuilder {
     }
 
 
+    ///This function works as add_operation_anon_transfer but this implement fees,
     pub fn add_operation_anon_transfer_fees(
         &mut self,
         inputs: &[OpenAnonBlindAssetRecord],
@@ -1853,7 +1855,7 @@ mod tests {
 
         let mut prng = ChaChaRng::from_seed([0u8; 32]);
 
-        let amount = 10i64;
+        let amount = 2000000i64;
         let amount_nonneg = Amount::from_nonnegative_i64(amount);
         assert!(amount_nonneg.is_ok());
 
@@ -1862,6 +1864,7 @@ mod tests {
         assert!(fee_amount_nonneg.is_ok());
 
         let amount_output = amount;
+        //let amount_output = 1000000i64;
         let amount_output_nonneg = Amount::from_nonnegative_i64(amount_output);
         assert!(amount_output_nonneg.is_ok());
 

--- a/tools/triple_masking/anonxfr_test_demo.sh
+++ b/tools/triple_masking/anonxfr_test_demo.sh
@@ -24,7 +24,7 @@ target/release/fn anon-transfer --amount 189990000 --anon-keys ./anon-keys-temp.
 
 randomiser2=$(tail -n 1 randomizers)
 echo "\n\n Owned Abars for Receiver1 after Anon Transfer 1"
-sleep 40
+sleep 30
 echo $randomiser2 > /dev/null
 target/release/fn owned-abars -p ptyo7hlqn-Eywf_ttG99OSWtz6KfDUvLYDDVDlV1C-U= -r $randomiser2
 
@@ -34,7 +34,7 @@ target/release/fn anon-transfer --amount 169990000 --anon-keys ./anon-keys-temp2
 
 randomiser3=$(tail -n 1 randomizers)
 echo "\n\n Owned Abars for Receiver2 after Anon Transfer 2"
-sleep 40
+sleep 30
 echo $randomiser3 > /dev/null
 target/release/fn owned-abars -p BdECoTzLNQHlKq1oGMI2kdh27yp_I2CZen0FGYLFkM0= -r $randomiser3
 

--- a/tools/triple_masking/anonxfr_test_demo.sh
+++ b/tools/triple_masking/anonxfr_test_demo.sh
@@ -20,21 +20,21 @@ set -e
 
 echo "\n\n\n Anonymous Transfer from Sender1 to Receiver1"
 echo "------------------------------------------------------------------------------"
-target/release/fn anon-transfer --amount 209990000 --anon-keys ./anon-keys-temp.keys --to-axfr-public-key ptyo7hlqn-Eywf_ttG99OSWtz6KfDUvLYDDVDlV1C-U= --to-enc-key SAmB7Oji4sAgENLaLb4PFclxQL_DRrEkXcYp6eXuXwI= --randomizer $randomiser1
+target/release/fn anon-transfer --amount 189990000 --anon-keys ./anon-keys-temp.keys --to-axfr-public-key ptyo7hlqn-Eywf_ttG99OSWtz6KfDUvLYDDVDlV1C-U= --to-enc-key SAmB7Oji4sAgENLaLb4PFclxQL_DRrEkXcYp6eXuXwI= --randomizer $randomiser1
 
 randomiser2=$(tail -n 1 randomizers)
 echo "\n\n Owned Abars for Receiver1 after Anon Transfer 1"
-sleep 20
+sleep 40
 echo $randomiser2 > /dev/null
 target/release/fn owned-abars -p ptyo7hlqn-Eywf_ttG99OSWtz6KfDUvLYDDVDlV1C-U= -r $randomiser2
 
 echo "\n\n\n Anonymous Transfer from Receiver1 (Sender2) to Receiver2"
 echo "------------------------------------------------------------------------------"
-target/release/fn anon-transfer --amount 209990000 --anon-keys ./anon-keys-temp2.keys --to-axfr-public-key BdECoTzLNQHlKq1oGMI2kdh27yp_I2CZen0FGYLFkM0= --to-enc-key Ox5L-mGxzOFfd4fef7WZGJMdO-EKBVnnJypZiEl_9FQ= --randomizer $randomiser2
+target/release/fn anon-transfer --amount 169990000 --anon-keys ./anon-keys-temp2.keys --to-axfr-public-key BdECoTzLNQHlKq1oGMI2kdh27yp_I2CZen0FGYLFkM0= --to-enc-key Ox5L-mGxzOFfd4fef7WZGJMdO-EKBVnnJypZiEl_9FQ= --randomizer $randomiser2
 
 randomiser3=$(tail -n 1 randomizers)
 echo "\n\n Owned Abars for Receiver2 after Anon Transfer 2"
-sleep 20
+sleep 40
 echo $randomiser3 > /dev/null
 target/release/fn owned-abars -p BdECoTzLNQHlKq1oGMI2kdh27yp_I2CZen0FGYLFkM0= -r $randomiser3
 

--- a/tools/triple_masking/anonxfr_test_demo.sh
+++ b/tools/triple_masking/anonxfr_test_demo.sh
@@ -1,6 +1,6 @@
+
 set -e
 ./tools/triple_masking/bar_to_abar_convert.sh
-
 randomiser1=$(tail -n 1 randomizers)
 echo "\n\n Owned Abars after Bar to Abar conversion"
 sleep 20 #Do not remove/decrease

--- a/tools/triple_masking/bar_to_abar_convert.sh
+++ b/tools/triple_masking/bar_to_abar_convert.sh
@@ -19,18 +19,11 @@ sleep 5
 # setup the new wallet
 set +e
 
-FILE_MNEMONIC="./mnemonic-temp.keys"
-FILE_ANON_KEYS="./anon-keys-temp.keys"
+FILE_MNEMONIC="mnemonic-temp.keys"
+FILE_ANON_KEYS="anon-keys-temp.keys"
 #rm mnemonic-temp.keys anon-keys-temp.keys
 
-if test -f $FILE_MNEMONIC; then
-    rm $FILE_MNEMONIC
-
-echo "double quit tape enough charge fancy mandate ostrich this program laundry insect either escape cement van turtle
-loud immense load tip spike inquiry spice" > $FILE_MNEMONIC
-
-if test -f $FILE_ANON_KEYS; then
-    rm $FILE_ANON_KEYS
+echo "double quit tape enough charge fancy mandate ostrich this program laundry insect either escape cement van turtle loud immense load tip spike inquiry spice" > $FILE_MNEMONIC
 
 echo "
 {
@@ -46,7 +39,7 @@ echo "==========================================================================
 target/release/fn setup -O $FILE_MNEMONIC -S http://0.0.0.0
 # convert bar to abar
 sleep 1
-target/release/fn convert-bar-to-abar --anon-keys $FILE_ANON_KEYS  --txo-sid 3
+target/release/fn convert-bar-to-abar --anon-keys ./$FILE_ANON_KEYS  --txo-sid 3
 
 echo "Bar 2 Abar Conversion demo script executed successfully!"
 echo "To check generated Abar run \`target/release/fn owned-abars -p zQa8j0mGYUXM6JxjWN_pqfOi1lvEyenJYq35OIJNN08= -r RANDOMIZER_STRING\`"

--- a/tools/triple_masking/bar_to_abar_convert.sh
+++ b/tools/triple_masking/bar_to_abar_convert.sh
@@ -18,23 +18,35 @@ sleep 5
 
 # setup the new wallet
 set +e
-rm mnemonic-temp.keys anon-keys-temp.keys
-echo "double quit tape enough charge fancy mandate ostrich this program laundry insect either escape cement van turtle loud immense load tip spike inquiry spice" >> mnemonic-temp.keys
+
+FILE_MNEMONIC="./mnemonic-temp.keys"
+FILE_ANON_KEYS="./anon-keys-temp.keys"
+#rm mnemonic-temp.keys anon-keys-temp.keys
+
+if test -f $FILE_MNEMONIC; then
+    rm $FILE_MNEMONIC
+
+echo "double quit tape enough charge fancy mandate ostrich this program laundry insect either escape cement van turtle
+loud immense load tip spike inquiry spice" > $FILE_MNEMONIC
+
+if test -f $FILE_ANON_KEYS; then
+    rm $FILE_ANON_KEYS
+
 echo "
 {
   \"axfr_secret_key\": \"J7PqRhmBOE_gadFs4rB4lcKuz_YoWa5VSlALyKuZdQjNBryPSYZhRczonGNY3-mp86LWW8TJ6clirfk4gk03Tw==\",
   \"axfr_public_key\": \"zQa8j0mGYUXM6JxjWN_pqfOi1lvEyenJYq35OIJNN08=\",
   \"enc_key\": \"Gu558brzFchoqQR9oi8QP54KZKSQ18Djzt82C4YUyFg=\",
   \"dec_key\": \"4GNC0J_qOXV2kww5BC5bOCyrTEfCodX5BoFaj06uN1s=\"
-}" >> anon-keys-temp.keys
+}" > anon-keys-temp.keys
 
 set -e
 echo "\n\n\n Bar To Abar Conversion"
 echo "==============================================================================="
-target/release/fn setup -O mnemonic-temp.keys -S http://0.0.0.0
+target/release/fn setup -O $FILE_MNEMONIC -S http://0.0.0.0
 # convert bar to abar
 sleep 1
-target/release/fn convert-bar-to-abar --anon-keys ./anon-keys-temp.keys  --txo-sid 3
+target/release/fn convert-bar-to-abar --anon-keys $FILE_ANON_KEYS  --txo-sid 3
 
 echo "Bar 2 Abar Conversion demo script executed successfully!"
 echo "To check generated Abar run \`target/release/fn owned-abars -p zQa8j0mGYUXM6JxjWN_pqfOi1lvEyenJYq35OIJNN08= -r RANDOMIZER_STRING\`"

--- a/tools/triple_masking/multi_axfr_test_demo.sh
+++ b/tools/triple_masking/multi_axfr_test_demo.sh
@@ -11,7 +11,7 @@ echo "
   \"axfr_public_key\": \"ptyo7hlqn-Eywf_ttG99OSWtz6KfDUvLYDDVDlV1C-U=\",
   \"enc_key\": \"SAmB7Oji4sAgENLaLb4PFclxQL_DRrEkXcYp6eXuXwI=\",
   \"dec_key\": \"AEq1ZUFk_fB__YaNjQ3D2taGOnMZAx4adpB6RbnPj24=\"
-}" >> anon-keys-temp2.keys
+}" > anon-keys-temp2.keys
 sleep 5
 set -e
 

--- a/tools/triple_masking/multi_axfr_test_demo.sh
+++ b/tools/triple_masking/multi_axfr_test_demo.sh
@@ -48,7 +48,7 @@ echo "Ox5L-mGxzOFfd4fef7WZGJMdO-EKBVnnJypZiEl_9FQ=
 ra4lQ6KhMhfLO1leXpI2Dj7qQcasbSOqNIVFAIRDHxw=
 GrvIiB1yXLajRr5V5yZggPOmSelQ1Ga9zxWTzp0RnB8=" > to_enc_key_file
 echo "100000000
-200000000
+100000000
 119980000" > amount_file
 
 echo "\n\n\n Batch Anonymous Transfer from Senders to Receivers"
@@ -59,13 +59,13 @@ target/release/fn anon-transfer-batch -n amount_file -s axfr_secretkey_file -d d
 tail -n 3 randomizers > randomizer_file2
 randomiser4=$(awk 'FNR>=1 && FNR<=1' randomizer_file2)
 echo "\n\n Owned Abars for Receiver1 after Batch Anon Transfer"
-sleep 20
+sleep 40
 echo $randomiser4 > /dev/null
 target/release/fn owned-abars -p BdECoTzLNQHlKq1oGMI2kdh27yp_I2CZen0FGYLFkM0= -r $randomiser4
 
 randomiser5=$(awk 'FNR>=3 && FNR<=3' randomizer_file2)
 echo "\n\n Owned Abars for Receiver3 after Batch Anon Transfer"
-sleep 20
+sleep 40
 echo $randomiser5 > /dev/null
 target/release/fn owned-abars -p 6dJt8oDrtXt3z-7__dOcDn7Q9lM8jd2RST0FJIfGspc= -r $randomiser5
 

--- a/tools/triple_masking/multi_axfr_test_demo.sh
+++ b/tools/triple_masking/multi_axfr_test_demo.sh
@@ -59,13 +59,13 @@ target/release/fn anon-transfer-batch -n amount_file -s axfr_secretkey_file -d d
 tail -n 3 randomizers > randomizer_file2
 randomiser4=$(awk 'FNR>=1 && FNR<=1' randomizer_file2)
 echo "\n\n Owned Abars for Receiver1 after Batch Anon Transfer"
-sleep 40
+sleep 30
 echo $randomiser4 > /dev/null
 target/release/fn owned-abars -p BdECoTzLNQHlKq1oGMI2kdh27yp_I2CZen0FGYLFkM0= -r $randomiser4
 
 randomiser5=$(awk 'FNR>=3 && FNR<=3' randomizer_file2)
 echo "\n\n Owned Abars for Receiver3 after Batch Anon Transfer"
-sleep 40
+sleep 30
 echo $randomiser5 > /dev/null
 target/release/fn owned-abars -p 6dJt8oDrtXt3z-7__dOcDn7Q9lM8jd2RST0FJIfGspc= -r $randomiser5
 


### PR DESCRIPTION
These are the changes to integrate the fees operation with the CLI.

There is a function that computes the remainder and adds an extra output which is sent back to the sender. Even If the remainder is "0" an extra output is added. The problem to avoid having an extra output to cash back "0 FRA" is that, if the remainder is exactly the amount to pay for an extra output, once the new fees are computed the remainder becomes zero

For example for one input, and three outputs, the fees are base(0.005) + (inputs) 0.001 + (outputs) 3 * 0.002 = 0.012

So, supposing the input is 10.014 and the outputs are 5, 3, and 2 

in this case 10.014 = 5.0 + 3.0 + 2.0  + (fees) 0.012 + (remainder) 0.002
as remainder is going to be an extra output fees become fees = base(0.005) + (inputs) 0.001 + (outputs) 4 * 0.002 = 0.014, then
10.014 = 5.0 + 3.0 + 2.0  + (fees) 0.014 + (remainder) 0.000

For that reason even when remainder is "0" an extra output is created.

Edit By Akhil - One known issue to this PR is, it is not currently not returning the randomizer of the remainder ABAR, which makes it inaccessible, but I fixed that in another branch which will be committed right after this PR is merged.