### PR TITLE
FO-846: fix state root error

### DIFF
--- a/src/components/contracts/baseapp/src/modules.rs
+++ b/src/components/contracts/baseapp/src/modules.rs
@@ -79,7 +79,6 @@ impl ModuleManager {
         let mut resp: ResponseEndBlock = Default::default();
         // Note: adding new modules need to be updated.
         self.account_module.end_block(ctx, req);
-        self.ethereum_module.end_block(ctx, req);
         self.evm_module.end_block(ctx, req);
         self.xhub_module.end_block(ctx, req);
         let resp_template = self.template_module.end_block(ctx, req);
@@ -87,6 +86,16 @@ impl ModuleManager {
             resp.validator_updates = resp_template.validator_updates;
         }
         resp
+    }
+
+    pub fn commit(
+        &mut self,
+        ctx: &mut Context,
+        height: u64,
+        root_hash: &[u8],
+    ) -> Result<()> {
+        self.ethereum_module
+            .commit(ctx, U256::from(height), root_hash)
     }
 
     pub fn process_tx<

--- a/src/components/contracts/modules/ethereum/src/impls.rs
+++ b/src/components/contracts/modules/ethereum/src/impls.rs
@@ -36,7 +36,12 @@ impl<C: Config> App<C> {
         )))
     }
 
-    pub fn store_block(&mut self, ctx: &mut Context, block_number: U256) -> Result<()> {
+    pub fn store_block(
+        &mut self,
+        ctx: &mut Context,
+        block_number: U256,
+        root_hash: &[u8],
+    ) -> Result<()> {
         // #[cfg(feature = "debug_env")]
         // const EVM_FIRST_BLOCK_HEIGHT: U256 = U256::from(142_5000);
         //
@@ -71,9 +76,8 @@ impl<C: Config> App<C> {
         let block_timestamp = ctx.header.time.clone().unwrap_or_default();
 
         let mut state_root = H256::default();
-        let root_hash = ctx.state.read().root_hash();
         if !root_hash.is_empty() {
-            state_root = H256::from_slice(&root_hash);
+            state_root = H256::from_slice(root_hash);
         }
 
         let partial_header = ethereum::PartialHeader {

--- a/src/components/contracts/modules/ethereum/src/lib.rs
+++ b/src/components/contracts/modules/ethereum/src/lib.rs
@@ -4,7 +4,6 @@
 mod basic;
 mod impls;
 
-use abci::{RequestEndBlock, ResponseEndBlock};
 use ethereum_types::{H160, H256, U256};
 use evm::Config as EvmConfig;
 use fp_core::{
@@ -116,13 +115,13 @@ impl<C: Config> Default for App<C> {
 }
 
 impl<C: Config> AppModule for App<C> {
-    fn end_block(
+    fn commit(
         &mut self,
         ctx: &mut Context,
-        req: &RequestEndBlock,
-    ) -> ResponseEndBlock {
-        let _ = ruc::info!(self.store_block(ctx, U256::from(req.height)));
-        Default::default()
+        height: U256,
+        root_hash: &[u8],
+    ) -> Result<()> {
+        self.store_block(ctx, height, root_hash)
     }
 }
 

--- a/src/components/contracts/primitives/core/src/module.rs
+++ b/src/components/contracts/primitives/core/src/module.rs
@@ -1,5 +1,6 @@
 use crate::context::Context;
 use abci::*;
+use fp_types::U256;
 use ruc::Result;
 
 /// AppModuleBasic is the standard form for basic non-dependant elements of an application module.
@@ -42,5 +43,14 @@ pub trait AppModule: AppModuleBasic {
         _req: &RequestEndBlock,
     ) -> ResponseEndBlock {
         Default::default()
+    }
+
+    fn commit(
+        &mut self,
+        _ctx: &mut Context,
+        _height: U256,
+        _root_hash: &[u8],
+    ) -> Result<()> {
+        Ok(())
     }
 }


### PR DESCRIPTION
The main reason why the state root is shown as unchanged is because the “root_hash()” function returns the root hash of the last commit without including the current pending transactions.

The “store_block()” function is populating the block info with all the pending transactions and the last commit hash. This hash doesn’t include the transactions that are about to be committed.

The root hash stored for each block is delayed because the process of storing block info is called during the block ender when the current root hash hasn’t been calculated yet.

The solution to this issue would be to call “store_block” after the root hash has been calculated on the state.


