### PR TITLE
Fix: make abar2bar args same as help

### DIFF
--- a/src/components/abciapp/Cargo.toml
+++ b/src/components/abciapp/Cargo.toml
@@ -69,3 +69,4 @@ vergen = "=3.1.0"
 default = ["diskcache"]
 diskcache = ["ledger/diskcache"]
 debug_env = ["ledger/debug_env", "config/debug_env"]
+

--- a/src/components/finutils/src/bins/fn.rs
+++ b/src/components/finutils/src/bins/fn.rs
@@ -459,7 +459,7 @@ fn run() -> Result<()> {
         let dec_key = anon_keys.dec_key;
         // get the BAR receiver address
         let to = m
-            .value_of("to-xfr-pubkey")
+            .value_of("to-pubkey")
             .c(d!())
             .and_then(wallet::public_key_from_base64)
             .or_else(|_| {


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [ ] make fmt
  - [ ] make lint
  - [ ] make test

* **The major changes of this PR**
https://github.com/FindoraNetwork/platform/blob/16a7e7d2087b7b92db1b66b25ffe3b20f18b2110/src/components/finutils/src/bins/fn.rs#L462 https://github.com/FindoraNetwork/platform/blob/16a7e7d2087b7b92db1b66b25ffe3b20f18b2110/src/components/finutils/src/bins/fn.yml#L602

* **Extra documentations**


