### PR TITLE
fix unpaid delegation

### DIFF
--- a/src/ledger/src/staking/mod.rs
+++ b/src/ledger/src/staking/mod.rs
@@ -1280,7 +1280,7 @@ impl Staking {
     fn delegation_process_finished_before_height(&mut self, h: BlockHeight) {
         self.delegation_info
             .end_height_map
-            .range(0..=h)
+            .range(0..h)
             .map(|(k, v)| (k.to_owned(), (*v).clone()))
             .collect::<Vec<_>>()
             .iter()


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**
    This method cleans up the paid delegations when the unstake reaches the block height 21 days in the future.
    If an account initiates an unstake operation at block height 20, it will change its status from bond to free 21 days later at block height 113420, then it will pay the delegate at 113421 and change its status from free to paid, so the current height cannot be included in the polling here.
    
    The following figure is the result of the test including the current height, in order to facilitate the test I will change the height of the state set to 5


![image](https://user-images.githubusercontent.com/31642966/167279784-ea7bd9c8-46b4-4491-9e1b-9eaf068faa53.png)




* **Extra documentations**


