### PR TITLE
FO-968: Increment Nonce for CheckTx run mode without executing EVM transaction 

### DIFF
--- a/src/components/contracts/baseapp/src/modules.rs
+++ b/src/components/contracts/baseapp/src/modules.rs
@@ -194,7 +194,7 @@ impl ModuleManager {
 
         origin_tx.validate::<Module>(ctx)?;
 
-        if RunTxMode::Deliver == ctx.run_mode {
+        if RunTxMode::Deliver == ctx.run_mode || RunTxMode::Check == ctx.run_mode {
             return origin_tx.apply::<Module>(ctx);
         }
         Ok(ActionResult::default())

--- a/src/components/contracts/modules/ethereum/src/lib.rs
+++ b/src/components/contracts/modules/ethereum/src/lib.rs
@@ -145,6 +145,15 @@ impl<C: Config> Executable for App<C> {
 impl<C: Config> ValidateUnsigned for App<C> {
     type Call = Action;
 
+    fn pre_execute(ctx: &Context, call: &Self::Call) -> Result<()> {
+        let Action::Transact(transaction) = call;
+        let origin = Self::recover_signer(transaction)
+            .ok_or_else(|| eg!("InvalidSignature, can not recover signer address"))?;
+        let account_id = C::AddressMapping::convert_to_account_id(origin);
+        C::AccountAsset::inc_nonce(ctx, &account_id)?;
+        Ok(())
+    }
+
     fn validate_unsigned(ctx: &Context, call: &Self::Call) -> Result<()> {
         let Action::Transact(transaction) = call;
         if let Some(chain_id) = transaction.signature.chain_id() {

--- a/src/components/contracts/modules/ethereum/tests/ethereum_integration.rs
+++ b/src/components/contracts/modules/ethereum/tests/ethereum_integration.rs
@@ -31,7 +31,10 @@ fn base_transfer_fee() -> U256 {
 
 fn build_transfer_transaction(to: H160, balance: U256) -> UncheckedTransaction<()> {
     let tx = UnsignedTransaction {
-        nonce: U256::zero(),
+        nonce: module_account::App::<BaseApp>::nonce(
+            &BASE_APP.lock().unwrap().check_state,
+            &ALICE_ECDSA.account_id,
+        ),
         gas_price: <BaseApp as module_ethereum::Config>::FeeCalculator::min_gas_price(),
         gas_limit: U256::from(0x100000),
         action: ethereum::TransactionAction::Call(to),

--- a/src/components/contracts/modules/evm/tests/evm_integration.rs
+++ b/src/components/contracts/modules/evm/tests/evm_integration.rs
@@ -120,7 +120,7 @@ fn test_deploy_check_tx() {
 
 fn test_deploy_deliver_tx() -> (H160, ethabi::Contract) {
     let mut req = RequestDeliverTx::default();
-    let (tx, contract_abi) = build_erc20_deploy_transaction("erc20", "FRA", 0.into());
+    let (tx, contract_abi) = build_erc20_deploy_transaction("erc20", "FRA", 1.into());
 
     let tx = serde_json::to_vec(&tx).unwrap();
     req.tx = EvmRawTxWrapper::wrap(&tx);
@@ -168,7 +168,7 @@ fn test_mint_check_tx(contract: ERC20) {
         contract,
         BOB_ECDSA.address,
         10000.into(),
-        1.into(),
+        2.into(),
     ))
     .unwrap();
     req.tx = EvmRawTxWrapper::wrap(&tx);
@@ -186,7 +186,7 @@ fn test_mint_deliver_tx(contract: ERC20) {
         contract,
         BOB_ECDSA.address,
         10000.into(),
-        1.into(),
+        3.into(),
     ))
     .unwrap();
     req.tx = EvmRawTxWrapper::wrap(&tx);
@@ -226,7 +226,7 @@ fn test_transfer_deliver_tx(contract: ERC20) {
         contract,
         ALICE_ECDSA.address,
         100.into(),
-        0.into(),
+        1.into(),
         U256::zero(),
         BOB_ECDSA.private_key,
     ))
@@ -245,7 +245,7 @@ fn test_transfer_deliver_tx(contract: ERC20) {
 fn test_balance_of_deliver_tx(contract: ERC20, who: H160) -> U256 {
     let mut req = RequestDeliverTx::default();
     let tx =
-        serde_json::to_vec(&build_erc20_balance_of_transaction(contract, who, 2.into()))
+        serde_json::to_vec(&build_erc20_balance_of_transaction(contract, who, 5.into()))
             .unwrap();
     req.tx = EvmRawTxWrapper::wrap(&tx);
     let resp = BASE_APP.lock().unwrap().deliver_tx(&req);

--- a/src/components/contracts/modules/template/tests/template_integration.rs
+++ b/src/components/contracts/modules/template/tests/template_integration.rs
@@ -75,13 +75,13 @@ fn test_abci_check_tx() {
     );
 
     // check balance
-    // fees are not deducted since tx is not simulated
+    // fees are deducted since tx is simulated for pre-execution
     assert_eq!(
         module_account::App::<BaseApp>::balance(
             &BASE_APP.lock().unwrap().check_state,
             &ALICE_XFR.pub_key.into()
         ),
-        U256::from(100_0000_0000_0000_0000_u64)
+        U256::from(99_0000_0000_0000_0000_u64)
     );
 }
 

--- a/tools/devnet/startnodes.sh
+++ b/tools/devnet/startnodes.sh
@@ -21,7 +21,7 @@ if [ -z "$Node" ] || ([ ! -z "$Node" ] && [ "$Node" = "$node" ]); then
         ENABLE_LEDGER_SERVICE=true \
         ENABLE_ETH_API_SERVICE=true \
         ENABLE_QUERY_SERVICE=true \
-        release/bin/abcid $DEVNET/$node >> $DEVNET/$node/abcid.log 2>&1  &
+        $BIN/abcid $DEVNET/$node >> $DEVNET/$node/abcid.log 2>&1  &
 fi
 done
 

--- a/tools/regression/evm.py
+++ b/tools/regression/evm.py
@@ -51,14 +51,14 @@ def transfer(arguments):
     w3 = Web3(HTTPProvider(to_web3_url(arguments['url'])))
     address = private_key_to_address(arguments['from_priv_key'], w3)
     signed_txn = w3.eth.account.sign_transaction(dict(
-            nonce=w3.eth.get_transaction_count(address),
-            gas=100000,
-            gasPrice=10000000000,
-            to=arguments['to_addr'],
-            value=int(arguments['amount']),
-            data=b'',
-            chainId=523,
-        ),
+        nonce=w3.eth.get_transaction_count(address, 'pending'),
+        gas=100000,
+        gasPrice=10000000000,
+        to=arguments['to_addr'],
+        value=int(arguments['amount']),
+        data=b'',
+        chainId=523,
+    ),
         arguments['from_priv_key'],
     )
     txn_hash = w3.eth.send_raw_transaction(signed_txn.rawTransaction)


### PR DESCRIPTION
1. Modified ValidateUnsigned trait - removed redundant validate call in pre execute function
2. Modified evm.py to use pending nonce when broadcasting a send transaction
3. Call apply for transaction check but only run pre-execute function
4. Updated startnodes.sh to use the variable $BIN instead of hard-coding release path  
