### PR TITLE
fix test failures caused by checkpoint.toml

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,6 +27,5 @@ nohup.out
 tools/tendermint
 seq_id.str
 utxo.map
-checkpoint.toml
 
 *.tmp

--- a/src/components/abciapp/src/abci/staking/test.rs
+++ b/src/components/abciapp/src/abci/staking/test.rs
@@ -1,5 +1,8 @@
 #![allow(missing_docs)]
 
+#[cfg(test)]
+use config::abci::global_cfg::create_abci_mock_config;
+
 use {
     finutils::txn_builder::{TransactionBuilder, TransferOperationBuilder},
     ledger::{
@@ -23,6 +26,7 @@ use {
 
 #[test]
 fn staking_block_rewards_rate() {
+    create_abci_mock_config();
     pnk!(check_block_rewards_rate());
 }
 

--- a/src/components/config/src/abci/mod.rs
+++ b/src/components/config/src/abci/mod.rs
@@ -190,14 +190,11 @@ pub mod global_cfg {
     use crate::abci::CheckPointConfig;
     #[cfg(target_os = "linux")]
     use btm::BtmCfg;
-    #[cfg(not(test))]
     #[cfg(target_os = "linux")]
     use btm::{SnapAlgo, SnapMode, STEP_CNT};
-    #[cfg(not(test))]
     use clap::{crate_authors, App, Arg, ArgMatches};
     use lazy_static::lazy_static;
     use ruc::*;
-    #[cfg(not(test))]
     use std::{env, process::exit};
 
     lazy_static! {
@@ -226,15 +223,19 @@ pub mod global_cfg {
         pub checkpoint: CheckPointConfig,
     }
 
-    #[cfg(test)]
-    fn get_config() -> Result<Config> {
-        Ok(Config {
-            ledger_dir: globutils::fresh_tmp_dir().to_string_lossy().into_owned(),
+    pub fn create_abci_mock_config() {
+        use std::{fs::File, io::Write};
+
+        let config = CheckPointConfig {
+            unbond_block_cnt: 3600 * 24 * 21 / 16,
             ..Default::default()
-        })
+        };
+        let mut file =
+            File::create("checkpoint.toml").expect("failed to create checkpoint.toml");
+        let content = toml::to_string(&config).unwrap();
+        file.write_all(content.as_bytes()).unwrap();
     }
 
-    #[cfg(not(test))]
     fn get_config() -> Result<Config> {
         let m = App::new("abcid")
             .version(env!("VERGEN_SHA"))
@@ -375,7 +376,6 @@ pub mod global_cfg {
         Ok(res)
     }
 
-    #[cfg(not(test))]
     fn print_version(m: &ArgMatches) {
         if m.is_present("version") {
             println!("{}", env!("VERGEN_SHA"));
@@ -383,7 +383,6 @@ pub mod global_cfg {
         }
     }
 
-    #[cfg(not(test))]
     #[cfg(target_os = "linux")]
     fn parse_btmcfg(m: &ArgMatches) -> Result<BtmCfg> {
         let mut res = BtmCfg::new();
@@ -439,7 +438,6 @@ pub mod global_cfg {
         Ok(res)
     }
 
-    #[cfg(not(test))]
     #[cfg(target_os = "linux")]
     fn list_snapshots(cfg: &BtmCfg) -> Result<()> {
         println!("Available snapshots are listed below:");
@@ -453,7 +451,6 @@ pub mod global_cfg {
         exit(0);
     }
 
-    #[cfg(not(test))]
     #[cfg(target_os = "linux")]
     fn check_rollback(m: &ArgMatches, cfg: &BtmCfg) -> Result<()> {
         const HINTS: &str = r#"    NOTE:

--- a/src/components/contracts/modules/ethereum/tests/ethereum_integration.rs
+++ b/src/components/contracts/modules/ethereum/tests/ethereum_integration.rs
@@ -4,6 +4,7 @@
 
 use abci::*;
 use baseapp::{BaseApp, ChainId};
+use config::abci::global_cfg::create_abci_mock_config;
 use ethereum_types::{H160, U256};
 use fp_mocks::*;
 use fp_traits::{account::AccountAsset, evm::FeeCalculator};
@@ -15,12 +16,17 @@ use fp_utils::tx::EvmRawTxWrapper;
 
 #[test]
 fn run_all_tests() {
+    setup();
     test_abci_check_tx();
     test_abci_begin_block();
     test_abci_deliver_tx();
     test_abci_end_block();
     test_abci_commit();
     test_abci_query()
+}
+
+fn setup() {
+    create_abci_mock_config();
 }
 
 fn base_transfer_fee() -> U256 {

--- a/src/components/contracts/modules/evm/tests/evm_integration.rs
+++ b/src/components/contracts/modules/evm/tests/evm_integration.rs
@@ -4,6 +4,7 @@ mod utils;
 
 use abci::*;
 use baseapp::{BaseApp, ChainId};
+use config::abci::global_cfg::create_abci_mock_config;
 use ethereum_types::{H160, H256, U256};
 use fp_evm::{CallOrCreateInfo, Runner};
 use fp_mocks::*;
@@ -68,8 +69,14 @@ fn build_erc20_balance_of_transaction(
     UncheckedTransaction::new_unsigned(function)
 }
 
+fn setup() {
+    create_abci_mock_config();
+}
+
 #[test]
 fn erc20_works() {
+    setup();
+
     test_mint_balance(
         &ALICE_ECDSA.account_id,
         100_0000_0000_0000_0000_u64.into(),

--- a/src/components/contracts/modules/template/Cargo.toml
+++ b/src/components/contracts/modules/template/Cargo.toml
@@ -24,3 +24,4 @@ fp-utils = { path = "../../primitives/utils" }
 fp-mocks = { path = "../../primitives/mocks" }
 fp-traits = { path = "../../primitives/traits" }
 module-account = { path = "../../modules/account" }
+config = { path = "../../../config" }

--- a/src/components/contracts/modules/template/tests/template_integration.rs
+++ b/src/components/contracts/modules/template/tests/template_integration.rs
@@ -2,6 +2,7 @@
 
 //! Template module integration tests.
 use abci::*;
+use config::abci::global_cfg::create_abci_mock_config;
 use fp_mocks::*;
 use fp_traits::account::{AccountAsset, FeeCalculator};
 use fp_types::{actions::template::Action as TemplateAction, actions::Action, U256};
@@ -10,8 +11,13 @@ use module_template::ValueStore;
 pub use std::borrow::Borrow;
 use std::convert::TryInto;
 
+fn setup() {
+    create_abci_mock_config();
+}
+
 #[test]
 fn run_all_tests() {
+    setup();
     test_abci_info();
     test_abci_init_chain();
     test_mint_balance(


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**
1. Fix check_tx error, such as `template_integraion`. If the default evm_checktx_nonce is 3000000, the txn will still be executed.
2. Create a mock checkpoint.toml in integration tests

* **Extra documentations**
![evm_checktx_nonce](https://user-images.githubusercontent.com/6870378/172094416-84a8ed6a-6ba2-48a4-b1c6-43bcd8fe4761.png)

![Test failure](https://user-images.githubusercontent.com/6870378/172094258-5b6cd2f9-6618-454e-808d-a7fc7a60fbbb.png)


