### PR TITLE
fix nonce not match

### DIFF
--- a/src/components/contracts/modules/ethereum/tests/ethereum_integration.rs
+++ b/src/components/contracts/modules/ethereum/tests/ethereum_integration.rs
@@ -73,7 +73,7 @@ fn test_abci_check_tx() {
     let tx2 = serde_json::to_vec(&build_transfer_transaction(
         BOB_ECDSA.address,
         10.into(),
-        U256::from(1),
+        U256::from(0),
     ))
     .unwrap();
     req.tx = EvmRawTxWrapper::wrap(&tx2);

--- a/src/components/contracts/modules/evm/tests/evm_integration.rs
+++ b/src/components/contracts/modules/evm/tests/evm_integration.rs
@@ -168,7 +168,7 @@ fn test_mint_check_tx(contract: ERC20) {
         contract,
         BOB_ECDSA.address,
         10000.into(),
-        2.into(),
+        1.into(),
     ))
     .unwrap();
     req.tx = EvmRawTxWrapper::wrap(&tx);
@@ -206,7 +206,7 @@ fn test_transfer_check_tx(contract: ERC20) {
         contract,
         ALICE_ECDSA.address,
         100.into(),
-        1.into(),
+        0.into(),
         U256::zero(),
         BOB_ECDSA.private_key,
     ))

--- a/src/components/contracts/modules/evm/tests/evm_integration.rs
+++ b/src/components/contracts/modules/evm/tests/evm_integration.rs
@@ -107,7 +107,7 @@ fn erc20_works() {
 fn test_deploy_check_tx() {
     let mut req = RequestCheckTx::default();
     let tx =
-        serde_json::to_vec(&build_erc20_deploy_transaction("erc20", "FRA", 1.into()).0)
+        serde_json::to_vec(&build_erc20_deploy_transaction("erc20", "FRA", 0.into()).0)
             .unwrap();
     req.tx = EvmRawTxWrapper::wrap(&tx);
     let resp = BASE_APP.lock().unwrap().check_tx(&req);


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [ ] make fmt
  - [ ] make lint
  - [ ] make test

* **The major changes of this PR**
Fix the problem that sending that transaction to the main network will result in incorrect nonce

The main reason is because the previous pre-execution logic does not specify the height,, that is, when evm_checktx_nonce does not reach the specified height, nonce will be in the check_tx in +1, and then go to execute execute, this time will be nonce check error


* **Extra documentations**


