### PR TITLE
update address32 to 34

### DIFF
--- a/src/components/contracts/primitives/types/Cargo.toml
+++ b/src/components/contracts/primitives/types/Cargo.toml
@@ -19,6 +19,7 @@ primitive-types = { version = "0.10.1", default-features = false, features = ["r
 ruc = "1.0"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0"
+serde-big-array = "0.4"
 sha3 = "0.10"
 zei = "0.2"
 zei-algebra = "0.2"


### PR DESCRIPTION
How about use address34 as the public key ?
Secp256k1: public key size is 33
Ed25519: public key size is 32
And in the zei, the XfrPublicKey is 34 (0 is the KeyType, 1..34 is the raw bytes).

And maybe we can delete `MultiSignature`, because the XfrPublicKey also supported the secp256k1 signature. Of course, this requires us to add `RecoveryId` to the signature in zei (length will 66). When calling in WASM, if it is called from metamask or like this, then add the KeyType in front of the signature.

