### PR TITLE
FO-1119 Fix fee for custom asset remainder

### DIFF
--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -1588,6 +1588,12 @@ impl AnonTransferOperationBuilder {
 
     #[allow(missing_docs)]
     pub fn extra_fee_estimation(&self) -> Result<u64> {
+        if self.inputs.len() > 5 {
+            return Err(eg!(
+                        "Total inputs (incl. fees) cannot be greater than 5"
+                    ));
+        }
+
         let input_sums =
             self.inputs
                 .iter()
@@ -1697,6 +1703,18 @@ impl AnonTransferOperationBuilder {
 
     /// build generates the anon transfer body with the Zero Knowledge Proof.
     pub fn build(&mut self) -> Result<&mut Self> {
+
+        if self.inputs.len() > 5 {
+            return Err(eg!(
+                        "Total inputs (incl. fees) cannot be greater than 5"
+                    ));
+        }
+        if self.outputs.len() > 5 {
+            return Err(eg!(
+                        "Total outputs (incl. remainders) cannot be greater than 5"
+                    ));
+        }
+
         let mut prng = ChaChaRng::from_entropy();
         let input_asset_list: HashSet<AssetType> = self
             .inputs
@@ -1764,15 +1782,18 @@ impl AnonTransferOperationBuilder {
                 let commitment = oabar_money_back.compute_commitment();
                 self.outputs.push(oabar_money_back);
                 self.commitments.push(commitment);
-
-                if self.outputs.len() > 5 {
-                    return Err(eg!(
-                        "Total outputs (incl. remainders) cannot be greater than 5"
-                    ));
-                }
             }
         }
 
+        if self.outputs.len() > 5 {
+            return Err(eg!(
+                        "Total outputs (incl. remainders) cannot be greater than 5"
+                    ));
+        }
+        web_sys::console::log_2(
+          &"Inputs and Outputs length\n".into(),
+            &format!("{}             {}\n\n", self.inputs.len(), self.outputs.len()).into(),
+        );
         let note = init_anon_xfr_note(
             self.inputs.as_slice(),
             self.outputs.as_slice(),

--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -1574,6 +1574,11 @@ impl AnonTransferOperationBuilder {
         abar: OpenAnonAssetRecord,
         secret_key: AXfrKeyPair,
     ) -> Result<&mut Self> {
+        if self.inputs.len() >= 5 {
+            return Err(eg!(
+                        "Total inputs (incl. fees) cannot be greater than 5"
+                    ));
+        }
         self.inputs.push(abar);
         self.keypairs.push(secret_key);
         Ok(self)
@@ -1581,6 +1586,11 @@ impl AnonTransferOperationBuilder {
 
     /// add_output is used to add a output record to the Anon Transfer factory
     pub fn add_output(&mut self, abar: OpenAnonAssetRecord) -> Result<&mut Self> {
+        if self.outputs.len() >= 5 {
+            return Err(eg!(
+                        "Total outputs (incl. remainders) cannot be greater than 5"
+                    ));
+        }
         self.commitments.push(abar.compute_commitment());
         self.outputs.push(abar);
         Ok(self)
@@ -1790,10 +1800,6 @@ impl AnonTransferOperationBuilder {
                         "Total outputs (incl. remainders) cannot be greater than 5"
                     ));
         }
-        web_sys::console::log_2(
-          &"Inputs and Outputs length\n".into(),
-            &format!("{}             {}\n\n", self.inputs.len(), self.outputs.len()).into(),
-        );
         let note = init_anon_xfr_note(
             self.inputs.as_slice(),
             self.outputs.as_slice(),

--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -1575,9 +1575,7 @@ impl AnonTransferOperationBuilder {
         secret_key: AXfrKeyPair,
     ) -> Result<&mut Self> {
         if self.inputs.len() >= 5 {
-            return Err(eg!(
-                        "Total inputs (incl. fees) cannot be greater than 5"
-                    ));
+            return Err(eg!("Total inputs (incl. fees) cannot be greater than 5"));
         }
         self.inputs.push(abar);
         self.keypairs.push(secret_key);
@@ -1588,8 +1586,8 @@ impl AnonTransferOperationBuilder {
     pub fn add_output(&mut self, abar: OpenAnonAssetRecord) -> Result<&mut Self> {
         if self.outputs.len() >= 5 {
             return Err(eg!(
-                        "Total outputs (incl. remainders) cannot be greater than 5"
-                    ));
+                "Total outputs (incl. remainders) cannot be greater than 5"
+            ));
         }
         self.commitments.push(abar.compute_commitment());
         self.outputs.push(abar);
@@ -1599,9 +1597,7 @@ impl AnonTransferOperationBuilder {
     #[allow(missing_docs)]
     pub fn extra_fee_estimation(&self) -> Result<u64> {
         if self.inputs.len() > 5 {
-            return Err(eg!(
-                        "Total inputs (incl. fees) cannot be greater than 5"
-                    ));
+            return Err(eg!("Total inputs (incl. fees) cannot be greater than 5"));
         }
 
         let input_sums =
@@ -1713,16 +1709,13 @@ impl AnonTransferOperationBuilder {
 
     /// build generates the anon transfer body with the Zero Knowledge Proof.
     pub fn build(&mut self) -> Result<&mut Self> {
-
         if self.inputs.len() > 5 {
-            return Err(eg!(
-                        "Total inputs (incl. fees) cannot be greater than 5"
-                    ));
+            return Err(eg!("Total inputs (incl. fees) cannot be greater than 5"));
         }
         if self.outputs.len() > 5 {
             return Err(eg!(
-                        "Total outputs (incl. remainders) cannot be greater than 5"
-                    ));
+                "Total outputs (incl. remainders) cannot be greater than 5"
+            ));
         }
 
         let mut prng = ChaChaRng::from_entropy();
@@ -1797,8 +1790,8 @@ impl AnonTransferOperationBuilder {
 
         if self.outputs.len() > 5 {
             return Err(eg!(
-                        "Total outputs (incl. remainders) cannot be greater than 5"
-                    ));
+                "Total outputs (incl. remainders) cannot be greater than 5"
+            ));
         }
         let note = init_anon_xfr_note(
             self.inputs.as_slice(),

--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -2530,4 +2530,51 @@ mod tests {
             .unwrap();
         (oabar, keypair)
     }
+
+    #[test]
+    pub fn test_extra_fee_estimation() {
+        let mut prng = ChaChaRng::from_seed([0u8;32]);
+        let k = AXfrKeyPair::generate(&mut prng);
+        {
+            let mut b = AnonTransferOperationBuilder::new_from_seq_id(0);
+
+            let _ = b.add_input(OpenAnonAssetRecordBuilder::new()
+                            .amount(1000000)
+                            .asset_type(ASSET_TYPE_FRA)
+                                    .pub_key(&k.get_pub_key())
+                                    .finalize(&mut prng)
+                                    .unwrap()
+                                    .build()
+                                    .unwrap(), k.clone());
+            let _fee = FEE_CALCULATING_FUNC(1, 1) as u64;
+            assert!(b.extra_fee_estimation().is_ok());
+            assert_eq!(b.extra_fee_estimation().unwrap(), 0);
+        }
+        {
+            let mut b = AnonTransferOperationBuilder::new_from_seq_id(0);
+
+            let _ = b.add_input(OpenAnonAssetRecordBuilder::new()
+                                    .amount(1000000)
+                                    .asset_type(ASSET_TYPE_FRA)
+                                    .pub_key(&k.get_pub_key())
+                                    .finalize(&mut prng)
+                                    .unwrap()
+                                    .build()
+                                    .unwrap(), k.clone());
+
+            let _ = b.add_output(OpenAnonAssetRecordBuilder::new()
+                .amount(1000000)
+                .asset_type(ASSET_TYPE_FRA)
+                .pub_key(&k.get_pub_key())
+                .finalize(&mut prng)
+                .unwrap()
+                .build()
+                .unwrap());
+
+            let fee = FEE_CALCULATING_FUNC(2, 2) as u64;
+            assert!(b.extra_fee_estimation().is_ok());
+            assert_eq!(b.extra_fee_estimation().unwrap(), fee);
+        }
+
+    }
 }

--- a/src/components/wasm/src/wasm.rs
+++ b/src/components/wasm/src/wasm.rs
@@ -1400,8 +1400,10 @@ impl AnonTransferOperationBuilder {
 
     /// get_expected_fee is used to gather extra FRA that needs to be spent to make the transaction
     /// have enough fees.
-    pub fn get_expected_fee(&self) -> u64 {
-        self.get_builder().extra_fee_estimation()
+    pub fn get_expected_fee(&self) -> Result<u64, JsValue> {
+        self.get_builder()
+            .extra_fee_estimation()
+            .map_err(error_to_jsvalue)
     }
 
     /// get_commitments returns a list of all the commitments for receiver public keys
@@ -2252,7 +2254,7 @@ mod test {
 
         let estimated_fees_gt_fra_excess = ts.get_expected_fee();
 
-        assert!(estimated_fees_gt_fra_excess > 0);
+        assert!(estimated_fees_gt_fra_excess.unwrap() > 0);
 
         let (mut oabar_2, keypair_in_2) =
             gen_oabar_and_keys(&mut prng, 2 * amount, asset_type);
@@ -2261,7 +2263,7 @@ mod test {
 
         let fra_excess_gt_fees_estimation = ts.get_expected_fee();
 
-        assert_eq!(fra_excess_gt_fees_estimation, 0);
+        assert_eq!(fra_excess_gt_fees_estimation, Ok(0));
     }
 
     fn gen_oabar_and_keys<R: CryptoRng + RngCore>(


### PR DESCRIPTION
For the new WASM API, we allow non FRA custom Assets to have
input amounts more than the output amounts and send the extra
amount back to sender during the build process.

This requires the fee estimator to calculate any possible custom-
asset-back outputs of the anon transfer transaction and include those
in the fee calculation.

The FRA requirement calculation logic has also been made linear.

* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**


* **The major impacts of this PR**
  - [x] Impact WASM?
  - [x] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

