### PR TITLE
[FO-1120] fix error in calculating the value of `Latest expected Return` in api `validator_detail`

### DIFF
--- a/src/components/abciapp/src/api/query_server/query_api/ledger_api.rs
+++ b/src/components/abciapp/src/api/query_server/query_api/ledger_api.rs
@@ -535,19 +535,19 @@ pub async fn query_validator_detail(
             };
             // Network Realtime APY
             let network_realtime_apy = ledger.staking_get_block_rewards_rate();
-            // Validator Realtime APY calculation
-            // Validator Consistency Factor = (Number of blocks proposed by validator / Total blocks the validator witnessed by validator  *  total staked by all validators / staked by validator)
-            // Validator Realtime APY =  Validator Consistency Factor * Network_Realtime_APY
-            // For a perfect validator consistency factor will be 1.
-            let validator_realtime_apy = [
-                network_realtime_apy[0] as u128
-                    * v_self_delegation.proposer_rwd_cnt as u128
-                    * staking.get_global_delegation_amount() as u128,
-                network_realtime_apy[1] as u128
-                    * (1 + staking.cur_height() - v_self_delegation.start_height)
-                        as u128
-                    * v.td_power as u128,
+
+            let commission_rate = v.get_commission_rate();
+
+            // Latest expected Return = % APY (annual) * (1 - commission %)
+            let one_sub_commission_rate = [
+                commission_rate[1] as u128 - commission_rate[0] as u128,
+                commission_rate[1] as u128,
             ];
+            let validator_realtime_apy = [
+                network_realtime_apy[0] * one_sub_commission_rate[0],
+                network_realtime_apy[1] * one_sub_commission_rate[1],
+            ];
+
             // fra_rewards: all delegators rewards including self-delegation
             let mut fra_rewards = v_self_delegation.rwd_amount;
             for (delegator, _) in &v.delegators {
@@ -561,7 +561,7 @@ pub async fn query_validator_detail(
                 is_online: v.signed_last_block,
                 voting_power: v.td_power,
                 voting_power_rank,
-                commission_rate: v.get_commission_rate(),
+                commission_rate,
                 self_staking: v_self_delegation
                     .delegations
                     .iter()

--- a/src/libs/merkle_tree/src/lib.rs
+++ b/src/libs/merkle_tree/src/lib.rs
@@ -1891,9 +1891,7 @@ impl AppendOnlyMerkle {
 
             match self.files[level].read_exact(buffer) {
                 Ok(()) => Ok(mem::transmute::<_, Block>(s)),
-                Err(e) => {
-                    Err(eg!(e))
-                }
+                Err(e) => Err(eg!(e)),
             }
         }
     }


### PR DESCRIPTION
Fix FO-1120

This is what is required in the documentation

![image](https://user-images.githubusercontent.com/31642966/183850321-28091f4f-76d8-4ff3-9104-d26295df781f.png)

eg. 09EF1DB6B67D1CBF7EBA6BD9B204611848993DF7
before: 308%

```jsonc
"validator_realtime_apy": [
    8.361847871253889e+37,
    2.773533508139776e+37
]
```

after: 19.2%

```jsonc
"validator_realtime_apy": [
    14787890782525169040000,
    76798321463198300000000
]
```
