### PR TITLE
Fix the amount in the `delegators` that staking did not modify when it punished the `validator`

### DIFF
--- a/src/components/config/src/abci/mod.rs
+++ b/src/components/config/src/abci/mod.rs
@@ -30,6 +30,7 @@ pub struct CheckPointConfig {
     pub fix_unpaid_delegation_height: u64,
     pub evm_checktx_nonce: i64,
     pub utxo_checktx_height: i64,
+    pub fix_delegators_am_height: u64,
 }
 
 impl CheckPointConfig {
@@ -58,6 +59,7 @@ impl CheckPointConfig {
                                 fix_unpaid_delegation_height: 0,
                                 evm_checktx_nonce: 0,
                                 utxo_checktx_height: 0,
+                                fix_delegators_am_height: 0,
                             };
                             #[cfg(not(feature = "debug_env"))]
                             let config = CheckPointConfig {
@@ -76,6 +78,7 @@ impl CheckPointConfig {
                                 fix_unpaid_delegation_height: 2261885,
                                 evm_checktx_nonce: 3000000,
                                 utxo_checktx_height: 2524270,
+                                fix_delegators_am_height: 30000000,
                             };
                             let content = toml::to_string(&config).unwrap();
                             file.write_all(content.as_bytes()).unwrap();

--- a/src/ledger/src/staking/mod.rs
+++ b/src/ledger/src/staking/mod.rs
@@ -1327,8 +1327,9 @@ impl Staking {
         }
 
         // punish itself
+        // the delegators under validator do not contain self-delegation message, so give a none on it.
         let am = self.delegation_get(addr).c(d!())?.amount();
-        self.governance_penalty_sub_amount(addr, am * percent[0] / percent[1])
+        self.governance_penalty_sub_amount(None, addr, am * percent[0] / percent[1])
             .c(d!())?;
 
         if self.addr_is_validator(addr) {
@@ -1342,8 +1343,14 @@ impl Staking {
                     .collect::<Vec<_>>()
             };
 
+            // also modify the amount in the delegators under validator,
+            // make the interface delegation_info and delegator_list data the same
             pl().into_iter().for_each(|(pk, p_am)| {
-                ruc::info_omit!(self.governance_penalty_sub_amount(&pk, p_am));
+                ruc::info_omit!(self.governance_penalty_sub_amount(
+                    Some(addr),
+                    &pk,
+                    p_am
+                ));
             });
 
             // punish its vote power
@@ -1359,13 +1366,14 @@ impl Staking {
     #[inline(always)]
     fn governance_penalty_sub_amount(
         &mut self,
-        addr: &XfrPublicKey,
+        validator: Option<&XfrPublicKey>,
+        delegator: &XfrPublicKey,
         mut am: Amount,
     ) -> Result<()> {
         let d = if let Some(d) = self
             .delegation_info
             .global_delegation_records_map
-            .get_mut(addr)
+            .get_mut(delegator)
         {
             d
         } else {
@@ -1404,6 +1412,27 @@ impl Staking {
             // NOTE:
             // punish rewards if principal is not enough
             d.rwd_amount = d.rwd_amount.saturating_sub(am);
+
+            // NOTE:
+            // the current height is greater than the specified height before execution,
+            // because to ensure the compatibility of historical data
+            if CFG.checkpoint.fix_delegators_am_height < self.cur_height {
+                if let Some(v) = validator {
+                    self.validator_get_effective_at_height_mut(self.cur_height)
+                        .c(d!("failed to get effective validators at current height"))
+                        .and_then(|cur| {
+                            cur.body
+                                .get_mut(v)
+                                .map(|v| {
+                                    if let Some(a) = v.delegators.get_mut(delegator) {
+                                        *a -= am;
+                                    }
+                                })
+                                .c(d!("delegator not exists"))
+                        })
+                        .map(|_| ())?;
+                }
+            }
         }
 
         Ok(())

--- a/src/libs/merkle_tree/src/lib.rs
+++ b/src/libs/merkle_tree/src/lib.rs
@@ -1891,9 +1891,7 @@ impl AppendOnlyMerkle {
 
             match self.files[level].read_exact(buffer) {
                 Ok(()) => Ok(mem::transmute::<_, Block>(s)),
-                Err(e) => {
-                    Err(eg!(e))
-                }
+                Err(e) => Err(eg!(e)),
             }
         }
     }


### PR DESCRIPTION
The problem is that when the validator received a penalty, the `delegations` in the `Delegation` structure did the deduction, while the `delegators` in the `Validator` structure did not do the deduction

Here are the results of the restoration
![1](https://user-images.githubusercontent.com/31642966/182503140-c419b419-53af-4abc-8fca-330b08f72c2a.png)
