### PR TITLE
Revert "update btm crate version (#440)"

### DIFF
--- a/src/components/abciapp/Cargo.toml
+++ b/src/components/abciapp/Cargo.toml
@@ -59,7 +59,7 @@ fp-storage = { path = "../contracts/primitives/storage" }
 fp-utils = { path = "../contracts/primitives/utils" }
 
 [target.'cfg(target_os= "linux")'.dependencies]
-btm = "0.7.2"
+btm = "0.1.6"
 
 [dev-dependencies]
 

--- a/src/components/config/Cargo.toml
+++ b/src/components/config/Cargo.toml
@@ -19,7 +19,7 @@ toml = "0.5.8"
 globutils = { path = "../../libs/globutils" }
 
 [target.'cfg(target_os= "linux")'.dependencies]
-btm = "0.7.2"
+btm = "0.1.6"
 
 [build-dependencies]
 vergen = "=3.1.0"

--- a/src/components/config/src/abci/mod.rs
+++ b/src/components/config/src/abci/mod.rs
@@ -441,18 +441,17 @@ pub mod global_cfg {
             if let Some(sm) = m.value_of("snapshot-mode") {
                 res.mode = SnapMode::from_string(sm).map_err(|e| d!("{}", e))?;
                 if !matches!(res.mode, SnapMode::External) {
-                    res.volume = m
+                    res.target = m
                         .value_of("snapshot-target")
                         .c(d!("Missing `snapshot-target`."))?
                         .to_owned();
                 }
             } else {
-                res.volume = m
+                res.target = m
                     .value_of("snapshot-target")
                     .c(d!("Missing `snapshot-target`."))?
                     .to_owned();
-                res.mode =
-                    BtmCfg::guess_mode(res.volume.as_str()).map_err(|e| d!("{}", e))?;
+                res.mode = res.guess_mode().map_err(|e| d!("{}", e))?;
             }
 
             if let Some(sa) = m.value_of("snapshot-algo") {
@@ -467,14 +466,13 @@ pub mod global_cfg {
             || m.is_present("snapshot-rollback-to-exact")
         {
             // this field should be parsed at the top
-            res.volume = m
+            res.target = m
                 .value_of("snapshot-target")
                 .c(d!("Missing `snapshot-target`."))?
                 .to_owned();
 
             // the guess should always success in this scene
-            res.mode =
-                BtmCfg::guess_mode(res.volume.as_str()).map_err(|e| d!("{}", e))?;
+            res.mode = res.guess_mode().map_err(|e| d!("{}", e))?;
 
             if m.is_present("snapshot-list") {
                 list_snapshots(&res).map_err(|e| d!("{}", e))?;


### PR DESCRIPTION
This reverts commit ec46b792954083c678aac674a8c0368a3875c9f2.

* **make sure that you have executed all the following process and no errors occur**
  - [ ] make fmt
  - [ ] make lint
  - [ ] make test

* **The major changes of this PR**


* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

