### PR TITLE
Bump up the Zei version in address-folding

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ x25519-dalek = { git = "https://github.com/FindoraNetwork/x25519-dalek" }
 bulletproofs = { git = "https://github.com/FindoraNetwork/bp" }
 
 
-zei = { git = "https://github.com/FindoraNetwork/zei", branch = "develop" }
-zei-accumulators = { git = "https://github.com/FindoraNetwork/zei", branch = "develop" }
-zei-algebra = { git = "https://github.com/FindoraNetwork/zei", branch = "develop" }
-zei-crypto = { git = "https://github.com/FindoraNetwork/zei", branch = "develop" }
-zei-plonk = { git = "https://github.com/FindoraNetwork/zei", branch = "develop" }
+zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.3" }
+zei-accumulators = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.3" }
+zei-algebra = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.3" }
+zei-crypto = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.3" }
+zei-plonk = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.3" }


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**

This PR bumps the Zei library to the latest version (with a fixed tag). The latest version, particularly, restore the ECC gate. 

This causes the proof size to be larger.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [x] Impact mainnet data compatibility?

* **Extra documentations**

