### PR TITLE
Modify the logic of the evm module side call `withdraw_fra`

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -23,6 +23,7 @@ members = [
     "src/components/contracts/modules/evm/precompile/sha3fips",
     "src/components/contracts/modules/evm/precompile/utils",
     "src/components/contracts/modules/evm/precompile/utils/macro",
+    "src/components/contracts/modules/evm/precompile/staking",
     "src/components/contracts/modules/xhub",
     "src/components/contracts/modules/template",
     "src/components/contracts/primitives/core",

--- a/src/components/contracts/baseapp/Cargo.toml
+++ b/src/components/contracts/baseapp/Cargo.toml
@@ -48,6 +48,7 @@ evm-precompile-basic = { path = "../modules/evm/precompile/basic" }
 evm-precompile-frc20 = { path = "../modules/evm/precompile/frc20" }
 evm-precompile-modexp = { path = "../modules/evm/precompile/modexp" }
 evm-precompile-sha3fips = { path = "../modules/evm/precompile/sha3fips" }
+evm-precompile-staking = { path = "../modules/evm/precompile/staking" }
 
 [features]
 abci_mock = []

--- a/src/components/contracts/baseapp/src/lib.rs
+++ b/src/components/contracts/baseapp/src/lib.rs
@@ -109,7 +109,7 @@ impl module_ethereum::Config for BaseApp {
 
 impl module_evm::Config for BaseApp {
     type AccountAsset = module_account::App<Self>;
-    type AddressMapping = EthereumAddressMapping;
+    type AddressMapping = module_account::App<Self>;
     type BlockGasLimit = BlockGasLimit;
     type BlockHashMapping = module_ethereum::App<Self>;
     type ChainId = ChainId;
@@ -125,6 +125,7 @@ impl module_evm::Config for BaseApp {
         evm_precompile_sha3fips::Sha3FIPS256,
         evm_precompile_sha3fips::Sha3FIPS512,
         evm_precompile_frc20::FRC20<Self>,
+        evm_precompile_staking::Staking<Self>,
     );
 }
 

--- a/src/components/contracts/baseapp/src/modules.rs
+++ b/src/components/contracts/baseapp/src/modules.rs
@@ -149,6 +149,12 @@ impl ModuleManager {
             // let transaction_index = pending_txs.as_ref().unwrap_or_default().len() as u32;
             let transaction_index = pending_txs.len() as u32;
 
+            let height = Some(ctx.block_header().height as u64);
+            let nonce =
+                module_account::App::<BaseApp>::account_of(ctx, &evm_from_addr, height)
+                    .unwrap_or_default()
+                    .nonce;
+
             let (tx, tx_status, receipt) = if asset == ASSET_TYPE_FRA {
                 let balance =
                     EthereumDecimalsMapping::from_native_token(U256::from(amount))
@@ -166,6 +172,7 @@ impl ModuleManager {
                     lowlevel,
                     transaction_index,
                     hash,
+                    nonce,
                 ) {
                     Ok(r) => r,
                     Err(e) => {

--- a/src/components/contracts/baseapp/src/modules.rs
+++ b/src/components/contracts/baseapp/src/modules.rs
@@ -134,11 +134,11 @@ impl ModuleManager {
 
         if CFG.checkpoint.prismxx_inital_height < ctx.header.height {
             let evm_from_bytes = keccak_256(from.as_bytes());
-            let evm_from_addr = Address::from(H160::from_slice(&evm_from_bytes[..20]));
-            let fra_from_addr = Address::from(from);
+            let evm_from_addr = H160::from_slice(&evm_from_bytes[..20]);
+            let from_addr = Address::from(evm_from_addr);
             module_account::App::<BaseApp>::insert_evm_fra_address_mapping(
                 ctx,
-                &fra_from_addr,
+                &from,
                 &evm_from_addr,
             )?;
 
@@ -151,7 +151,7 @@ impl ModuleManager {
 
             let height = Some(ctx.block_header().height as u64);
             let nonce =
-                module_account::App::<BaseApp>::account_of(ctx, &evm_from_addr, height)
+                module_account::App::<BaseApp>::account_of(ctx, &from_addr, height)
                     .unwrap_or_default()
                     .nonce;
 
@@ -162,11 +162,11 @@ impl ModuleManager {
                             eg!("The transfer to account amount is too large")
                         })?;
 
-                module_account::App::<BaseApp>::mint(ctx, &evm_from_addr, balance)?;
+                module_account::App::<BaseApp>::mint(ctx, &from_addr, balance)?;
 
                 match self.evm_module.evm_call(
                     ctx,
-                    &evm_from_addr,
+                    &from_addr,
                     &target,
                     balance,
                     lowlevel,
@@ -185,7 +185,7 @@ impl ModuleManager {
                 self.evm_module.withdraw_frc20(
                     ctx,
                     asset.0,
-                    &evm_from_addr,
+                    &from_addr,
                     &target,
                     U256::from(amount),
                     lowlevel,

--- a/src/components/contracts/modules/account/Cargo.toml
+++ b/src/components/contracts/modules/account/Cargo.toml
@@ -15,6 +15,8 @@ primitive-types = { version = "0.10.1", default-features = false, features = ["r
 ruc = "1.0"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
+zei = "0.2"
+zei-algebra = "0.2"
 
 # primitives, don't depend on any modules
 fp-core = { path = "../../primitives/core" }

--- a/src/components/contracts/modules/account/src/impls.rs
+++ b/src/components/contracts/modules/account/src/impls.rs
@@ -160,4 +160,12 @@ impl<C: Config> AccountAsset<Address> for App<C> {
     ) -> Result<()> {
         Allowances::insert(ctx.state.write().borrow_mut(), owner, spender, &amount)
     }
+
+    fn insert_evm_fra_address_mapping(
+        ctx: &Context,
+        fra_pk: &Address,
+        evm_address: &Address,
+    ) -> Result<()> {
+        EvmFraAddressMapping::insert(ctx.state.write().borrow_mut(), evm_address, fra_pk)
+    }
 }

--- a/src/components/contracts/modules/account/src/impls.rs
+++ b/src/components/contracts/modules/account/src/impls.rs
@@ -5,8 +5,9 @@ use fp_core::{account::SmartAccount, context::Context};
 use fp_storage::{Borrow, BorrowMut};
 use fp_traits::account::AccountAsset;
 use fp_types::crypto::Address;
-use primitive_types::U256;
+use primitive_types::{H160, U256};
 use ruc::*;
+use zei::xfr::sig::XfrPublicKey;
 
 impl<C: Config> AccountAsset<Address> for App<C> {
     fn total_issuance(ctx: &Context) -> U256 {
@@ -166,8 +167,8 @@ impl<C: Config> AccountAsset<Address> for App<C> {
 impl<C: Config> App<C> {
     pub fn insert_evm_fra_address_mapping(
         ctx: &Context,
-        fra_pk: &Address,
-        evm_address: &Address,
+        fra_pk: &XfrPublicKey,
+        evm_address: &H160,
     ) -> Result<()> {
         EvmFraAddressMapping::insert(ctx.state.write().borrow_mut(), evm_address, fra_pk)
     }

--- a/src/components/contracts/modules/account/src/impls.rs
+++ b/src/components/contracts/modules/account/src/impls.rs
@@ -160,8 +160,11 @@ impl<C: Config> AccountAsset<Address> for App<C> {
     ) -> Result<()> {
         Allowances::insert(ctx.state.write().borrow_mut(), owner, spender, &amount)
     }
+}
 
-    fn insert_evm_fra_address_mapping(
+/// impl outside of trait
+impl<C: Config> App<C> {
+    pub fn insert_evm_fra_address_mapping(
         ctx: &Context,
         fra_pk: &Address,
         evm_address: &Address,

--- a/src/components/contracts/modules/account/src/lib.rs
+++ b/src/components/contracts/modules/account/src/lib.rs
@@ -40,6 +40,9 @@ mod storage {
     // The owner approve his amount of funds to the spender.
     // owner => spender => amount
     generate_storage!(Account, Allowances => DoubleMap<Address, Address, U256>);
+
+    // evm_address => fra_pk
+    generate_storage!(Account, EvmFraAddressMapping => Map<Address, Address>);
 }
 
 #[derive(Clone)]

--- a/src/components/contracts/modules/evm/precompile/basic/src/lib.rs
+++ b/src/components/contracts/modules/evm/precompile/basic/src/lib.rs
@@ -16,8 +16,11 @@
 // limitations under the License.
 
 use core::cmp::min;
-use evm::{ExitError, ExitSucceed};
-use module_evm::precompile::{LinearCostPrecompile, PrecompileId};
+use evm::{Context, ExitError, ExitSucceed};
+use evm::executor::PrecompileOutput;
+use fp_types::H160;
+use module_evm::{Config, precompile::{LinearCostPrecompile, PrecompileId}};
+use module_evm::precompile::{FinState, Precompile};
 
 /// The identity precompile.
 pub struct Identity;
@@ -163,3 +166,4 @@ impl LinearCostPrecompile for ECRecoverPublicKey {
         Ok((ExitSucceed::Returned, pubkey.to_vec()))
     }
 }
+

--- a/src/components/contracts/modules/evm/precompile/frc20/Cargo.toml
+++ b/src/components/contracts/modules/evm/precompile/frc20/Cargo.toml
@@ -22,3 +22,4 @@ slices = "0.2.0"
 baseapp = { path = "../../../../baseapp" }
 fp-mocks = { path = "../../../../primitives/mocks" }
 sha3 = "0.10"
+globutils = { path = "../../../../../../libs/globutils" }

--- a/src/components/contracts/modules/evm/src/lib.rs
+++ b/src/components/contracts/modules/evm/src/lib.rs
@@ -71,6 +71,8 @@ pub mod storage {
     generate_storage!(EVM, AccountCodes => Map<HA160, Vec<u8>>);
     // Storage root hash related to the contract account.
     generate_storage!(EVM, AccountStorages => DoubleMap<HA160, HA256, H256>);
+
+
 }
 
 #[derive(Clone)]
@@ -105,7 +107,7 @@ impl<C: Config> App<C> {
         let asset = Token::FixedBytes(Vec::from(_asset));
 
         let bytes: &[u8] = _from.as_ref();
-        let from = Token::FixedBytes(bytes.to_vec());
+        let from = Token::Address(H160::from_slice(&bytes[4..24]));
 
         let bytes: &[u8] = _to.as_ref();
         let to = Token::Address(H160::from_slice(&bytes[4..24]));
@@ -164,7 +166,7 @@ impl<C: Config> App<C> {
         let function = self.contracts.bridge.function("withdrawFRA").c(d!())?;
 
         let bytes: &[u8] = _from.as_ref();
-        let from = Token::FixedBytes(bytes.to_vec());
+        let from = Token::Address(H160::from_slice(&bytes[4..24]));
 
         let bytes: &[u8] = _to.as_ref();
 

--- a/src/components/contracts/modules/evm/src/lib.rs
+++ b/src/components/contracts/modules/evm/src/lib.rs
@@ -148,6 +148,7 @@ impl<C: Config> App<C> {
             from,
             self.contracts.bridge_address,
             logs,
+            U256::zero(),
         ))
     }
 
@@ -160,6 +161,7 @@ impl<C: Config> App<C> {
         _lowlevel: Vec<u8>,
         transaction_index: u32,
         transaction_hash: H256,
+        nonce: U256,
     ) -> Result<(TransactionV0, TransactionStatus, Receipt)> {
         let bytes: &[u8] = _from.as_ref();
         let source = H160::from_slice(&bytes[4..24]);
@@ -168,7 +170,6 @@ impl<C: Config> App<C> {
         let target = H160::from_slice(&bytes[4..24]);
 
         let gas_limit = 9999999;
-        let value = U256::zero();
         let gas_price = U256::one();
 
         let (_, logs, used_gas) = ActionRunner::<C>::execute_systemc_contract(
@@ -177,7 +178,7 @@ impl<C: Config> App<C> {
             source,
             gas_limit,
             target,
-            value,
+            _value,
         )?;
 
         let action = TransactionAction::Call(target);
@@ -185,7 +186,7 @@ impl<C: Config> App<C> {
         Ok(Self::system_transaction(
             transaction_hash,
             _lowlevel,
-            value,
+            _value,
             action,
             U256::from(gas_limit),
             gas_price,
@@ -194,6 +195,7 @@ impl<C: Config> App<C> {
             source,
             target,
             logs,
+            nonce,
         ))
     }
 
@@ -234,6 +236,7 @@ impl<C: Config> App<C> {
         from: H160,
         to: H160,
         logs: Vec<Log>,
+        nonce: U256,
     ) -> (TransactionV0, TransactionStatus, Receipt) {
         let signature_fake = H256([
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -241,7 +244,7 @@ impl<C: Config> App<C> {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x02,
         ]);
         let tx = TransactionV0 {
-            nonce: U256::zero(),
+            nonce,
             gas_price,
             gas_limit,
             value,

--- a/src/components/contracts/modules/evm/src/lib.rs
+++ b/src/components/contracts/modules/evm/src/lib.rs
@@ -184,7 +184,7 @@ impl<C: Config> App<C> {
 
         Ok(Self::system_transaction(
             transaction_hash,
-            _lowlevel.clone(),
+            _lowlevel,
             value,
             action,
             U256::from(gas_limit),

--- a/src/components/contracts/modules/evm/src/system_contracts.rs
+++ b/src/components/contracts/modules/evm/src/system_contracts.rs
@@ -23,7 +23,7 @@ impl SystemContracts {
         let bridge = Contract::load(abi_str.as_bytes()).c(d!())?;
 
         let owner =
-            H160::from_str("0x72488bAa718F52B76118C79168E55c209056A2E6").c(d!())?;
+            H160::from_str("0xBB6ed61e686090a4718A1FD8dD0035D41C48Fa84").c(d!())?;
 
         let salt = H256::zero();
 

--- a/src/components/contracts/primitives/mocks/src/lib.rs
+++ b/src/components/contracts/primitives/mocks/src/lib.rs
@@ -20,7 +20,7 @@ use std::env::temp_dir;
 use std::path::PathBuf;
 use std::sync::Mutex;
 use std::time::SystemTime;
-use zei::xfr::sig::XfrKeyPair;
+use zei::xfr::sig::{XfrKeyPair, XfrPublicKey};
 
 lazy_static! {
     pub static ref BASE_APP: Mutex<BaseApp> =
@@ -31,6 +31,14 @@ lazy_static! {
         XfrKeyPair::generate(&mut ChaChaRng::from_entropy());
     pub static ref BOB_XFR: XfrKeyPair =
         XfrKeyPair::generate(&mut ChaChaRng::from_entropy());
+}
+
+pub fn test_insert_address_mapping(evm_address: &H160, fra_pk: &XfrPublicKey) {
+    module_account::App::<BaseApp>::insert_evm_fra_address_mapping(
+        &BASE_APP.lock().unwrap().deliver_state,
+        fra_pk,
+        evm_address
+    ).unwrap();
 }
 
 pub fn test_mint_balance(who: &Address, balance: U256, height: u64) {

--- a/src/components/contracts/primitives/traits/src/account.rs
+++ b/src/components/contracts/primitives/traits/src/account.rs
@@ -57,11 +57,11 @@ pub trait AccountAsset<Address> {
         amount: U256,
     ) -> Result<()>;
 
-    fn insert_evm_fra_address_mapping(
-        ctx: &Context,
-        fra_pk: &Address,
-        evm_address: &Address,
-    ) -> Result<()>;
+    // fn insert_evm_fra_address_mapping(
+    //     ctx: &Context,
+    //     fra_pk: &Address,
+    //     evm_address: &Address,
+    // ) -> Result<()>;
 }
 
 /// Outputs the current transaction fee.

--- a/src/components/contracts/primitives/traits/src/account.rs
+++ b/src/components/contracts/primitives/traits/src/account.rs
@@ -56,6 +56,12 @@ pub trait AccountAsset<Address> {
         spender: &Address,
         amount: U256,
     ) -> Result<()>;
+
+    fn insert_evm_fra_address_mapping(
+        ctx: &Context,
+        fra_pk: &Address,
+        evm_address: &Address,
+    ) -> Result<()>;
 }
 
 /// Outputs the current transaction fee.

--- a/src/components/contracts/primitives/traits/src/evm.rs
+++ b/src/components/contracts/primitives/traits/src/evm.rs
@@ -2,10 +2,13 @@ use core::{convert::From, ops::Div};
 use fp_core::context::Context;
 use fp_types::crypto::Address;
 use primitive_types::{H160, H256, U256};
+
 use ruc::Result;
 
 pub trait AddressMapping {
     fn convert_to_account_id(address: H160) -> Address;
+
+    fn fra_pubkey(ctx: &Context, address: &H160) -> Vec<u8>;
 }
 
 /// Ethereum address mapping.
@@ -14,6 +17,10 @@ pub struct EthereumAddressMapping;
 impl AddressMapping for EthereumAddressMapping {
     fn convert_to_account_id(address: H160) -> Address {
         Address::from(address)
+    }
+
+    fn fra_pubkey(_ctx: &Context, _address: &H160) -> Vec<u8> {
+        todo!()
     }
 }
 


### PR DESCRIPTION
Modify `withdraw_fra` to `evm_call`, not to call prism's bridge, directly call the contract

After executing `contract-deposit` four times nonce is 3

![4](https://user-images.githubusercontent.com/31642966/184903845-382a46e3-4f66-47d4-b293-249f9c99fc6f.png)

![5](https://user-images.githubusercontent.com/31642966/184903877-88e75a84-438b-43f8-9139-8a329c3ea9a4.png)

Request web3 interface eth_getTransactionCount visible nonce of 4

```jsonc

POST http://127.0.0.1:8545
Content-Type: application/json

{
    "jsonrpc":"2.0",
    "method":"eth_getTransactionCount",
    "params":["0x39627a7f94981fb6232921d2f515e1f65a58d072", "latest"],
    "id":1
}


```
![6](https://user-images.githubusercontent.com/31642966/184908674-a60d3e87-ff86-4877-85b3-639caa79020c.png)


