### PR TITLE
Added EVM_FIRST_BLOCK_HEIGHT to avoid potential test failures due to …

### DIFF
--- a/tools/devnet/env.sh
+++ b/tools/devnet/env.sh
@@ -7,7 +7,7 @@ NC='\033[0m'
 
 # default environment values
 DEFAULT_BIN_CFG="debug"
-DEFAULT_BLOCK_INTERVAL="5"
+DEFAULT_BLOCK_INTERVAL="2"
 DEFAULT_ENDPOINT="http://0.0.0.0"
 
 # binary config

--- a/tools/devnet/env.sh
+++ b/tools/devnet/env.sh
@@ -18,11 +18,12 @@ export BIN="target/$BIN_CFG"
 export BLOCK_INTERVAL="${BLOCK_INTERVAL:=$DEFAULT_BLOCK_INTERVAL}"
 export ENDPOINT="${ENDPOINT:=$DEFAULT_ENDPOINT}"
 
-# paths
+# paths and misc
 TMP_DEBUG=/tmp/findora
 export FIN_DEBUG="${FIN_DEBUG:=$TMP_DEBUG}"
 export DEVNET="$FIN_DEBUG/devnet"
 export WALLET="$HOME/.findora"
+export EVM_FIRST_BLOCK_HEIGHT="${EVM_FIRST_BLOCK_HEIGHT:=1}"
 
 # logs
 ABCI_LOG_LEVEL="abciapp=info,baseapp=info,account=info,ethereum=info,evm=info,eth_rpc=info"


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [ ] make fmt
  - [ ] make lint
  - [ ] make test

* **The major changes of this PR**
1. Added EVM_FIRST_BLOCK_HEIGHT variable to avoid potential test failures due to Blockscout fix on main branch
2. Integration passed: https://jenkins.dev.findora.org/view/integration%20test/job/Manual%20Integration%20Test/24/

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

