### PR TITLE
Use zei v0.2.4 in address-folding branch

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ x25519-dalek = { git = "https://github.com/FindoraNetwork/x25519-dalek" }
 bulletproofs = { git = "https://github.com/FindoraNetwork/bp" }
 
 
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.3" }
-zei-accumulators = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.3" }
-zei-algebra = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.3" }
-zei-crypto = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.3" }
-zei-plonk = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.3" }
+zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.4" }
+zei-accumulators = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.4" }
+zei-algebra = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.4" }
+zei-crypto = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.4" }
+zei-plonk = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.4" }

--- a/src/components/contracts/baseapp/Cargo.toml
+++ b/src/components/contracts/baseapp/Cargo.toml
@@ -25,8 +25,8 @@ serde_json = "1.0.40"
 attohttpc = { version = "0.18", default-features = false, features = ["compress", "json", "tls-rustls"] }
 base64 = "0.12"
 once_cell = "1.10.0"
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
 
 # primitives
 fp-core = { path = "../primitives/core" }

--- a/src/components/contracts/modules/account/Cargo.toml
+++ b/src/components/contracts/modules/account/Cargo.toml
@@ -25,6 +25,6 @@ fp-types = { path = "../../primitives/types" }
 [dev-dependencies]
 parking_lot = "0.12"
 rand_chacha = "0.3"
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
 zei = "0.2"

--- a/src/components/contracts/modules/ethereum/Cargo.toml
+++ b/src/components/contracts/modules/ethereum/Cargo.toml
@@ -36,8 +36,8 @@ config = { path = "../../../config"}
 baseapp = { path = "../../baseapp" }
 fp-mocks = { path = "../../primitives/mocks" }
 module-account = { path = "../account" }
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
 
 [features]
 default = []

--- a/src/components/contracts/modules/evm/Cargo.toml
+++ b/src/components/contracts/modules/evm/Cargo.toml
@@ -35,8 +35,8 @@ fp-traits = { path = "../../primitives/traits" }
 fp-types = { path = "../../primitives/types" }
 fp-utils = { path = "../../primitives/utils" }
 config = { path = "../../../config"}
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
 ledger = { path = "../../../../ledger" }
 
 [dev-dependencies]

--- a/src/components/contracts/primitives/core/Cargo.toml
+++ b/src/components/contracts/primitives/core/Cargo.toml
@@ -16,8 +16,8 @@ parking_lot = "0.12"
 primitive-types = { version = "0.10.1", default-features = false, features = ["rlp", "byteorder", "serde"] }
 ruc = "1.0"
 serde = { version = "1.0.124", features = ["derive"] }
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1", optional = true }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1", optional = true }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2", optional = true }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2", optional = true }
 serde_with = { version = "1.9.4"}
 
 # primitives

--- a/src/components/contracts/primitives/storage/Cargo.toml
+++ b/src/components/contracts/primitives/storage/Cargo.toml
@@ -15,10 +15,10 @@ ruc = "1.0"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.10"
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
 
 # primitives
 fp-core = { path = "../core" }
 
 [dev-dependencies]
-temp_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
+temp_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }

--- a/src/components/finutils/src/bins/fn.rs
+++ b/src/components/finutils/src/bins/fn.rs
@@ -669,8 +669,7 @@ fn run() -> Result<()> {
             Some(path) => {
                 let f =
                     fs::read_to_string(path).c(d!("Failed to read anon-keys file"))?;
-                let keys = serde_json::from_str::<AnonKeys>(f.as_str()).c(d!())?;
-                keys
+                serde_json::from_str::<AnonKeys>(f.as_str()).c(d!())?
             }
             None => return Err(eg!("path for anon-keys file not found")),
         };

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -66,8 +66,8 @@ features = ["f16", "serde"]
 [target.'cfg(not(target_arch = "wasm32"))'.dependencies]
 parking_lot = "0.12"
 fs2 = "0.4"
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
 sparse_merkle_tree = { path = "../libs/sparse_merkle_tree" }
 zei-accumulators = "0.2"
 

--- a/src/ledger/src/data_model/mod.rs
+++ b/src/ledger/src/data_model/mod.rs
@@ -2273,7 +2273,7 @@ impl StateCommitmentData {
 }
 
 /// Commitment data for Anon merkle trees
-#[derive(Debug, Clone, Serialize, Deserialize, PartialEq)]
+#[derive(Debug, Clone, Serialize, Deserialize, Eq, PartialEq)]
 pub struct AnonStateCommitmentData {
     /// Root hash of the latest committed version of abar merkle tree
     pub abar_root_hash: BLSScalar,

--- a/src/libs/cryptohash/src/lib.rs
+++ b/src/libs/cryptohash/src/lib.rs
@@ -105,7 +105,7 @@ pub mod sha256 {
 
 #[repr(C)]
 #[allow(missing_docs)]
-#[derive(Copy, Clone, Debug, Default, PartialEq, Deserialize, Serialize)]
+#[derive(Copy, Clone, Debug, Default, Eq, PartialEq, Deserialize, Serialize)]
 pub struct HashValue {
     pub hash: [u8; HASH_SIZE],
 }

--- a/src/libs/sparse_merkle_tree/Cargo.toml
+++ b/src/libs/sparse_merkle_tree/Cargo.toml
@@ -24,8 +24,8 @@ serde = "1.0.124"
 serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.10"
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
 zei = "0.2"
 
 [dev-dependencies]
-temp_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1" }
+temp_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**

This PR points zei to a newer release, which will serialize the Bulletproofs over secq256k1 with some compression to reduce the proof size.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [x] Impact mainnet data compatibility?

* **Extra documentations**

