### PR TITLE
Bump zei from v0.2.4 to v0.2.5

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -69,8 +69,8 @@ x25519-dalek = { git = "https://github.com/FindoraNetwork/x25519-dalek" }
 bulletproofs = { git = "https://github.com/FindoraNetwork/bp" }
 
 
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.4" }
-zei-accumulators = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.4" }
-zei-algebra = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.4" }
-zei-crypto = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.4" }
-zei-plonk = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.4" }
+zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.5" }
+zei-accumulators = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.5" }
+zei-algebra = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.5" }
+zei-crypto = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.5" }
+zei-plonk = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.2.5" }


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**

Zei library has a renaming that may affect how data is serialized in the JSON representation. Aka, it is breaking. 
This PR bumps up to the latest version.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [x] Impact mainnet data compatibility?

* **Extra documentations**

