### PR TITLE
fix undelegation missing reward bug

### DIFF
--- a/src/components/abciapp/src/abci/staking/mod.rs
+++ b/src/components/abciapp/src/abci/staking/mod.rs
@@ -290,8 +290,8 @@ pub fn system_mint_pay(
         })
         .chain(staking.delegation_get_global_rewards().into_iter().map(
             |(k, (n, receiver_pk))| {
-                let pk = if CFG.checkpoint.fix_undelegation_missing_reward_height
-                    < td_height
+                let pk = if td_height
+                    <= CFG.checkpoint.fix_undelegation_missing_reward_height
                 {
                     Some(k)
                 } else {


### PR DESCRIPTION
https://github.com/FindoraNetwork/platform/pull/430
此pr修复主网会把解质押的21天内产生的奖励丢失问题

此次修复以上pr checkpoint错误导致历史数据不兼容问题
添加checkpoint之后，main分支加载主网历史数据，目前已经追上
![image](https://user-images.githubusercontent.com/26101255/186792579-37bcec96-f76f-4c92-846a-911f61aa5e81.png)
![image](https://user-images.githubusercontent.com/26101255/186792278-5eecd0b8-6f23-4161-8cdb-b594fa70a122.png)