### PR TITLE
add docs for `fn dev`, and extend functions

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -98,6 +98,7 @@ tendermint_goleveldb:
 	cd tools/tendermint && $(MAKE) install
 
 test:
+	- find src -name "checkpoint.toml" | xargs rm -f
 	cargo test --release --workspace -- --test-threads=1 # --nocapture
 	- find src -name "checkpoint.toml" | xargs rm -f
 

--- a/Makefile
+++ b/Makefile
@@ -40,7 +40,7 @@ define pack
 		${CARGO_TARGET_DIR}/$(2)/$(1)/staking_cfg_generator \
 		$(shell go env GOPATH)/bin/tendermint \
 		$(1)/$(bin_dir)/
-	cp $(1)/$(bin_dir)/* ~/.cargo/bin/
+	cp -f $(1)/$(bin_dir)/* ~/.cargo/bin/
 	cd $(1)/$(bin_dir)/ && ./findorad pack
 	cp -f /tmp/findorad $(1)/$(bin_dir)/
 	cp -f /tmp/findorad ~/.cargo/bin/

--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
-![](https://tokei.rs/b1/github/FindoraNetwork/platform)
 ![GitHub top language](https://img.shields.io/github/languages/top/FindoraNetwork/platform)
+[![Minimum rustc version](https://img.shields.io/badge/rustc-1.63+-lightgray.svg)](https://github.com/rust-random/rand#rust-version-requirements)
 ![GitHub Workflow Status](https://img.shields.io/github/workflow/status/FindoraNetwork/platform/Develop)
 ![Docker Pulls](https://img.shields.io/docker/pulls/findoranetwork/findorad)
 ![GitHub issues](https://img.shields.io/github/issues-raw/FindoraNetwork/platform)
@@ -9,7 +9,6 @@
 # Findora Platform
 
 - [**Wiki**](https://wiki.findora.org/)
-- [**Contribution Guide**](docs/contribution_guide.md)
 - [**Change Log**](docs/CHANGELOG.md)
 
 ### Licensing
@@ -19,7 +18,3 @@ The primary license for Platform is the Business Source License 1.1 (`BUSL-1.1`)
 ### Exceptions
 
 - All files in `components/contracts` are licensed under `Apache-2.0`
-
-### SEE ALSO
-
-- [**Zei**](https://github.com/FindoraNetwork/zei)

--- a/docs/fn_dev.md
+++ b/docs/fn_dev.md
@@ -1,0 +1,6 @@
+# `fn dev`
+
+A powerful and convenient development tool for managing local clusters of FindoraNetwork.
+Its goal is to replace some existing rudimentary development environment management tools, such as: `make debug_env` and `make devnet`.
+
+Check [**moduler documentation**](../src/components/finutils/src/common/dev/README.md) for details.

--- a/src/components/finutils/src/bins/fn.rs
+++ b/src/components/finutils/src/bins/fn.rs
@@ -458,6 +458,12 @@ fn run() -> Result<()> {
             if let Some(ip) = sm.value_of("host_ip") {
                 envcfg.host_ip = Some(ip.to_owned());
             }
+            if let Some(tm_bin) = sm.value_of("tendermint_bin_path") {
+                envcfg.tendermint_bin = Some(tm_bin.to_owned());
+            }
+            if let Some(abcid_bin) = sm.value_of("abcid_bin_path") {
+                envcfg.abcid_bin = Some(abcid_bin.to_owned());
+            }
             Ops::Create
         } else if let Some(sm) = m.subcommand_matches("destroy") {
             if let Some(name) = sm.value_of("env_name") {

--- a/src/components/finutils/src/bins/fn.rs
+++ b/src/components/finutils/src/bins/fn.rs
@@ -464,6 +464,8 @@ fn run() -> Result<()> {
                 envcfg.name = name.to_owned();
             }
             Ops::Destroy
+        } else if m.subcommand_matches("destroy-all").is_some() {
+            Ops::DestroyAll
         } else if let Some(sm) = m.subcommand_matches("start") {
             if let Some(name) = sm.value_of("env_name") {
                 envcfg.name = name.to_owned();
@@ -489,11 +491,17 @@ fn run() -> Result<()> {
                 envcfg.name = name.to_owned();
             }
             Ops::Info
+        } else if m.subcommand_matches("info-all").is_some() {
+            Ops::InfoAll
+        } else if m.subcommand_matches("list").is_some() {
+            Ops::List
         } else if let Some(sm) = m.subcommand_matches("init") {
             if let Some(name) = sm.value_of("env_name") {
                 envcfg.name = name.to_owned();
             }
             Ops::Init
+        } else if m.subcommand_matches("init-all").is_some() {
+            Ops::InitAll
         } else {
             if let Some(name) = m.value_of("env_name") {
                 envcfg.name = name.to_owned();

--- a/src/components/finutils/src/bins/fn.yml
+++ b/src/components/finutils/src/bins/fn.yml
@@ -561,6 +561,8 @@ subcommands:
                   takes_value: true
                   value_name: ENV NAME
                   required: false
+        - destroy-all:
+            about: Destroy all existing ENVs
         - start:
             about: Start an existing env
             args:
@@ -611,6 +613,10 @@ subcommands:
                   takes_value: true
                   value_name: ENV NAME
                   required: false
+        - info-all:
+            about: Show the details of all existing ENVs
+        - list:
+            about: List the names of all existing ENVs
         - init:
             about: Config the initial settings(POS,FRA issuance...)
             args:
@@ -621,3 +627,5 @@ subcommands:
                   takes_value: true
                   value_name: ENV NAME
                   required: false
+        - init-all:
+            about: Apply the `init` operation to all existing ENVs

--- a/src/components/finutils/src/bins/fn.yml
+++ b/src/components/finutils/src/bins/fn.yml
@@ -551,6 +551,20 @@ subcommands:
                   takes_value: true
                   value_name: HOST IP
                   required: false
+              - tendermint_bin_path:
+                  help: The path of your custom tendermint binary
+                  short: T
+                  long: tendermint-bin-path
+                  takes_value: true
+                  value_name: TENDERMINT BIN PATH
+                  required: false
+              - abcid_bin_path:
+                  help: The path of your custom abcid binary
+                  short: A
+                  long: abcid-bin-path
+                  takes_value: true
+                  value_name: ABCID BIN PATH
+                  required: false
         - destroy:
             about: Destroy an existing env
             args:

--- a/src/components/finutils/src/bins/stt/init/mod.rs
+++ b/src/components/finutils/src/bins/stt/init/mod.rs
@@ -14,7 +14,7 @@ use {
 
 pub fn init(mut interval: u64, is_mainnet: bool, skip_validator: bool) -> Result<()> {
     if 0 == interval {
-        interval = BLOCK_INTERVAL;
+        interval = *BLOCK_INTERVAL;
     }
 
     if !skip_validator {

--- a/src/components/finutils/src/bins/stt/stt.rs
+++ b/src/components/finutils/src/bins/stt/stt.rs
@@ -50,7 +50,7 @@ macro_rules! sleep_n_block {
         sleep_ms!((n * itv * 1000.0) as u64);
     }};
     ($n_block: expr) => {
-        sleep_n_block!($n_block, ledger::staking::BLOCK_INTERVAL)
+        sleep_n_block!($n_block, *ledger::staking::BLOCK_INTERVAL)
     };
 }
 

--- a/src/components/finutils/src/common/dev/README.md
+++ b/src/components/finutils/src/common/dev/README.md
@@ -82,7 +82,68 @@ Below is the information of a custom ENV named 'MyEnv', `fn dev -e MyEnv`:
     "mnemonic_words": "field ranch pencil chest effort coyote april move injury illegal forest amount bid sound mixture use second pet embrace twice total essay valve loan"
   },
   "initial_validator_number": 6,
-  "initial_pos_settings": [],
+  "initial_pos_settings": [
+    {
+      "tendermint_addr": "27055305231CF6F718AD26485499B3ED1CCC8115",
+      "tendermint_pubkey": "MVQUuYdJzxmYiJnmffxf40jBXXkwwnkLzt0f4XV+NeQ=",
+      "xfr_keypair": {
+        "pub_key": "5vy5t4sG_cbLVJvKQWn7xwd7WSmRQlUX6KW-IvDTLBo=",
+        "sec_key": "fCBBCZCh8-IxCn9rgjoRiX03_SiuI99EouM-VJ9Hu5U="
+      },
+      "xfr_mnemonic": "chat fish hedgehog step help waste charge repeat cram public address visa around iron sponsor silly obvious sail squirrel relief arrive pet toe nominee",
+      "xfr_wallet_addr": "fra1um7tndutqm7udj65n09yz60mcurhkkffj9p929lg5klz9uxn9sdqlv3f2e"
+    },
+    {
+      "tendermint_addr": "33A24EF38E695529EED806CF70751C2CFC61DEAC",
+      "tendermint_pubkey": "bvjpaBraL50Q8rRo+a7HH5HU2YI4lEasxm5CrP/TC6c=",
+      "xfr_keypair": {
+        "pub_key": "MOm22HEhE59rIb9H2Vgg_-Y0EOaIolKUbGcWXdfyZdM=",
+        "sec_key": "AVj4I7G85a_dpETRjZbEYAlAiP7kBGxUx-3YBmYfhDc="
+      },
+      "xfr_mnemonic": "inject clerk accuse crunch absurd piece rely property bird win cave occur panther shaft switch device ketchup amused rather tragic settle celery dose brick",
+      "xfr_wallet_addr": "fra1xr5mdkr3yyfe76epharajkpqllnrgy8x3z3999rvvut9m4ljvhfsjf5375"
+    },
+    {
+      "tendermint_addr": "38AD0AF0258FB751262BD9D835A4D7848B0BC60E",
+      "tendermint_pubkey": "5UzQOmtN9xT7kOLq9w0B4UA1U5dUeuJgzItbGkdepvg=",
+      "xfr_keypair": {
+        "pub_key": "zH51NYSEam0rA8aJTFlyxHY-t3KFAg9uTnZ47l0HTCI=",
+        "sec_key": "S-WS-_maS1beU8fKBpTKBXUzZ8i1-9q44MlXYFiddak="
+      },
+      "xfr_mnemonic": "repeat noise rare rely open crucial awkward firm distance about detect connect style device wagon level check grow bench year toddler rubber sense advice",
+      "xfr_wallet_addr": "fra1e3l82dvys34x62crc6y5cktjc3mradmjs5pq7mjwweuwuhg8fs3qpwjk0r"
+    },
+    {
+      "tendermint_addr": "4F850CA6849EC0B3FC808D912F35CE2DAA222006",
+      "tendermint_pubkey": "l+7AqB4df3ckzpF+7Ku4xh9z+WPzhyzjw99WKE0K9oI=",
+      "xfr_keypair": {
+        "pub_key": "RyqsOAAqHeEGW2AKwywDX7GgOTP5XjMfAnYlufOKmIM=",
+        "sec_key": "CvaTBun0MiEeSErqHMPKRih0ADIu_UUjzuFQ2zdekuw="
+      },
+      "xfr_mnemonic": "harbor all speed train adult alien box steel promote discover desk antique please ship total carry coral deer method nominee blanket ghost brand have",
+      "xfr_wallet_addr": "fra1gu42cwqq9gw7zpjmvq9vxtqrt7c6qwfnl90rx8czwcjmnuu2nzpsmg9205"
+    },
+    {
+      "tendermint_addr": "C81783A1C67AD00C82FF093CE36AFF938185E44B",
+      "tendermint_pubkey": "QPh4cyJnFKpDwDbU0C30hoQfqwvjCN9xDB8OtomhMkE=",
+      "xfr_keypair": {
+        "pub_key": "THNbrDo9hoWDCJKePWhFG3KWDhK7Hd76-envNmOLmOM=",
+        "sec_key": "inIf4M_Pr_9O845CCp_BvMakx-lnjFaNPTvRUMSFv3E="
+      },
+      "xfr_mnemonic": "cricket know material crop wheel merge imitate script sing pioneer honey safe access inquiry wall best sign seed hybrid helmet wheat grocery stone west",
+      "xfr_wallet_addr": "fra1f3e4htp68krgtqcgj20r66z9rdefvrsjhvwaa7hea8hnvcutnr3spzuwm3"
+    },
+    {
+      "tendermint_addr": "FAD1E8BBC00835B88FAA41B54EAA0D2FCE55FEF0",
+      "tendermint_pubkey": "i3QFHggYCqG6ciKmsjAXSt6NKfyUOGjfje5YwYaYOfo=",
+      "xfr_keypair": {
+        "pub_key": "UtKUdsJTYLCbmAXUAWGb97zMyW0HvyADxsrz7T4vmG0=",
+        "sec_key": "o9aYwKN27PC3OPa7GqDpvP5q5WPoJk-qjRp4KTgNeok="
+      },
+      "xfr_mnemonic": "fever cheap upper flash team language town sudden cash nurse orphan dove nation possible bracket coil hello orchard hurdle feature excuse rigid flee basic",
+      "xfr_wallet_addr": "fra12tffgakz2dstpxucqh2qzcvm777vejtdq7ljqq7xete76030npks7w80ku"
+    }
+  ],
   "block_interval": 1,
   "evm_chain_id": 777,
   "checkpoint_file": "/tmp/checkpoint.toml",
@@ -90,113 +151,113 @@ Below is the information of a custom ENV named 'MyEnv', `fn dev -e MyEnv`:
   "seed_nodes": {
     "0": {
       "id": 0,
-      "tm_id": "7caec7b3a25c3966c6603452c9095a1e2ff19785",
-      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/0",
+      "tendermint_node_id": "91a4fa7b110d051bf9bc832622afb41d97f27997",
+      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/0",
       "kind": "Seed",
-      "ports": {
-        "web3_http": 44752,
-        "web3_ws": 30047,
-        "tm_p2p": 37377,
-        "tm_rpc": 23863,
-        "app_abci": 42327,
-        "app_8669": 39832,
-        "app_8668": 45102
+      "occupied_ports": {
+        "web3_http_service": 27411,
+        "web3_websocket_service": 24958,
+        "tendermint_p2p_service": 32670,
+        "tendermint_rpc_service": 56727,
+        "abcid_abci_service": 56761,
+        "abcid_submission_service": 20372,
+        "abcid_ledger_query_service": 30015
       }
     }
   },
   "validator_or_full_nodes": {
     "1": {
       "id": 1,
-      "tm_id": "bb81551e737b232285ecd563c499ba56a9335ed8",
-      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/1",
-      "kind": "Node",
-      "ports": {
-        "web3_http": 39118,
-        "web3_ws": 38781,
-        "tm_p2p": 43052,
-        "tm_rpc": 52559,
-        "app_abci": 32767,
-        "app_8669": 45090,
-        "app_8668": 58272
+      "tendermint_node_id": "4d4cdfb807697b680bffcf8cfbb6f90c43d60884",
+      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/1",
+      "kind": "ValidatorOrFull",
+      "occupied_ports": {
+        "web3_http_service": 29062,
+        "web3_websocket_service": 34909,
+        "tendermint_p2p_service": 46897,
+        "tendermint_rpc_service": 30160,
+        "abcid_abci_service": 40160,
+        "abcid_submission_service": 58302,
+        "abcid_ledger_query_service": 38985
       }
     },
     "2": {
       "id": 2,
-      "tm_id": "25af74b05bd5a312f64ef2155ad2844e87cbf1a4",
-      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/2",
-      "kind": "Node",
-      "ports": {
-        "web3_http": 30247,
-        "web3_ws": 30301,
-        "tm_p2p": 62187,
-        "tm_rpc": 34517,
-        "app_abci": 59392,
-        "app_8669": 39727,
-        "app_8668": 42059
+      "tendermint_node_id": "4b66d6e9e8e8e9277afda3024eda5474690f68aa",
+      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/2",
+      "kind": "ValidatorOrFull",
+      "occupied_ports": {
+        "web3_http_service": 28888,
+        "web3_websocket_service": 31504,
+        "tendermint_p2p_service": 34962,
+        "tendermint_rpc_service": 25973,
+        "abcid_abci_service": 37529,
+        "abcid_submission_service": 39327,
+        "abcid_ledger_query_service": 33283
       }
     },
     "3": {
       "id": 3,
-      "tm_id": "03eac7c59230e345cfc0a030dbd2c1bad003c75c",
-      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/3",
-      "kind": "Node",
-      "ports": {
-        "web3_http": 62442,
-        "web3_ws": 34670,
-        "tm_p2p": 33516,
-        "tm_rpc": 40108,
-        "app_abci": 62630,
-        "app_8669": 61792,
-        "app_8668": 41703
+      "tendermint_node_id": "ef3e3dddeb5955efc8ef4905184008a28e4482b7",
+      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/3",
+      "kind": "ValidatorOrFull",
+      "occupied_ports": {
+        "web3_http_service": 46711,
+        "web3_websocket_service": 31297,
+        "tendermint_p2p_service": 56883,
+        "tendermint_rpc_service": 52160,
+        "abcid_abci_service": 39108,
+        "abcid_submission_service": 26479,
+        "abcid_ledger_query_service": 56173
       }
     },
     "4": {
       "id": 4,
-      "tm_id": "0892a3c97b664ea35c6f7815b0dc20699a0b2a13",
-      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/4",
-      "kind": "Node",
-      "ports": {
-        "web3_http": 25335,
-        "web3_ws": 30296,
-        "tm_p2p": 21710,
-        "tm_rpc": 49938,
-        "app_abci": 33458,
-        "app_8669": 42395,
-        "app_8668": 23640
+      "tendermint_node_id": "cc55016ba689320bbdb95d5922fc14d02716119e",
+      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/4",
+      "kind": "ValidatorOrFull",
+      "occupied_ports": {
+        "web3_http_service": 29555,
+        "web3_websocket_service": 34764,
+        "tendermint_p2p_service": 28830,
+        "tendermint_rpc_service": 33124,
+        "abcid_abci_service": 22525,
+        "abcid_submission_service": 26205,
+        "abcid_ledger_query_service": 25639
       }
     },
     "5": {
       "id": 5,
-      "tm_id": "0a184e1f6faddb86cbf42940a739345965021dbe",
-      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/5",
-      "kind": "Node",
-      "ports": {
-        "web3_http": 38777,
-        "web3_ws": 64178,
-        "tm_p2p": 34144,
-        "tm_rpc": 36390,
-        "app_abci": 30303,
-        "app_8669": 32079,
-        "app_8668": 24219
+      "tendermint_node_id": "ba1cdbbf61b59520f01ee6769777edc0a4af8a07",
+      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/5",
+      "kind": "ValidatorOrFull",
+      "occupied_ports": {
+        "web3_http_service": 55174,
+        "web3_websocket_service": 57460,
+        "tendermint_p2p_service": 47144,
+        "tendermint_rpc_service": 48775,
+        "abcid_abci_service": 29531,
+        "abcid_submission_service": 46879,
+        "abcid_ledger_query_service": 49426
       }
     },
     "6": {
       "id": 6,
-      "tm_id": "7bf456af4aa2ae6e933876d2da62a5e6109a141e",
-      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/6",
-      "kind": "Node",
-      "ports": {
-        "web3_http": 22716,
-        "web3_ws": 22631,
-        "tm_p2p": 47611,
-        "tm_rpc": 57745,
-        "app_abci": 26842,
-        "app_8669": 40852,
-        "app_8668": 54885
+      "tendermint_node_id": "bda665baeb0a82c8e9892358fe082dd1ead5ff2a",
+      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/6",
+      "kind": "ValidatorOrFull",
+      "occupied_ports": {
+        "web3_http_service": 46340,
+        "web3_websocket_service": 64310,
+        "tendermint_p2p_service": 24224,
+        "tendermint_rpc_service": 23894,
+        "abcid_abci_service": 41878,
+        "abcid_submission_service": 50118,
+        "abcid_ledger_query_service": 31215
       }
     }
   },
-  "tendermint_genesis_config": "{\"app_hash\":\"\",\"chain_id\":\"test-chain-zfWF7p\",\"consensus_params\":{\"block\":{\"max_bytes\":\"22020096\",\"max_gas\":\"-1\",\"time_iota_ms\":\"1000\"},\"evidence\":{\"max_age_duration\":\"172800000000000\",\"max_age_num_blocks\":\"100000\"},\"validator\":{\"pub_key_types\":[\"ed25519\"]}},\"genesis_time\":\"2022-09-05T18:11:48.125514813Z\",\"validators\":[{\"address\":\"1EC4D45D32369471CFC2D72BA13BBC763F8F7F01\",\"name\":\"node-0\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"1JLCxVB57o6O0kvKO4SqcxnVbbiyy8cOFJZ6VaXNPRE=\"},\"voting_power\":\"1\"},{\"address\":\"7860BD6D1E825C0BD64E58CAAF007028F22EB6EF\",\"name\":\"node-1\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"34JI8V8j/z4wT9MRtpZF3AtNdJxwt8guQfn4lhdnLUM=\"},\"voting_power\":\"1\"},{\"address\":\"AD1EE8FCCB2D69C2FD0E038DA431B0A0264B1F2D\",\"name\":\"node-2\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"ajDU9S6SMwkBtvIyJ838CuGDLq+MN6ZUFjWfRAY2rp4=\"},\"voting_power\":\"1\"},{\"address\":\"860FCA9E795E1982BEAC75F7DBF1A8E55D82749C\",\"name\":\"node-3\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"MJm6lkkwW2ZYd2Z1QTwAK5eLPvmzcFpYAi+PN4XthJ0=\"},\"voting_power\":\"1\"},{\"address\":\"19272E9A28AE77D81A2B2768F1C2B9EA75AC8670\",\"name\":\"node-4\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"3yyNXD503Fctiwmbw8JTk2jdZBDA2Drm9CkSw/VCTvo=\"},\"voting_power\":\"1\"},{\"address\":\"078E2E0F813C3B92032812E6E87A2D3262A55A2C\",\"name\":\"node-5\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"Ygg2h6SAsNSud/PsGSiJ86KjXdeeUa+dqiV4zGPcDok=\"},\"voting_power\":\"1\"}]}",
+  "tendermint_genesis_config": "{\"app_hash\":\"\",\"chain_id\":\"test-chain-wfnI4D\",\"consensus_params\":{\"block\":{\"max_bytes\":\"22020096\",\"max_gas\":\"-1\",\"time_iota_ms\":\"1000\"},\"evidence\":{\"max_age_duration\":\"172800000000000\",\"max_age_num_blocks\":\"100000\"},\"validator\":{\"pub_key_types\":[\"ed25519\"]}},\"genesis_time\":\"2022-09-06T01:25:39.871204204Z\",\"validators\":[{\"address\":\"38AD0AF0258FB751262BD9D835A4D7848B0BC60E\",\"name\":\"node-0\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"5UzQOmtN9xT7kOLq9w0B4UA1U5dUeuJgzItbGkdepvg=\"},\"voting_power\":\"1\"},{\"address\":\"27055305231CF6F718AD26485499B3ED1CCC8115\",\"name\":\"node-1\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"MVQUuYdJzxmYiJnmffxf40jBXXkwwnkLzt0f4XV+NeQ=\"},\"voting_power\":\"1\"},{\"address\":\"FAD1E8BBC00835B88FAA41B54EAA0D2FCE55FEF0\",\"name\":\"node-2\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"i3QFHggYCqG6ciKmsjAXSt6NKfyUOGjfje5YwYaYOfo=\"},\"voting_power\":\"1\"},{\"address\":\"4F850CA6849EC0B3FC808D912F35CE2DAA222006\",\"name\":\"node-3\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"l+7AqB4df3ckzpF+7Ku4xh9z+WPzhyzjw99WKE0K9oI=\"},\"voting_power\":\"1\"},{\"address\":\"33A24EF38E695529EED806CF70751C2CFC61DEAC\",\"name\":\"node-4\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"bvjpaBraL50Q8rRo+a7HH5HU2YI4lEasxm5CrP/TC6c=\"},\"voting_power\":\"1\"},{\"address\":\"C81783A1C67AD00C82FF093CE36AFF938185E44B\",\"name\":\"node-5\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"QPh4cyJnFKpDwDbU0C30hoQfqwvjCN9xDB8OtomhMkE=\"},\"voting_power\":\"1\"}]}",
   "next_node_id": 7
 }
 ```

--- a/src/components/finutils/src/common/dev/README.md
+++ b/src/components/finutils/src/common/dev/README.md
@@ -1,8 +1,330 @@
-# fn dev
+# `fn dev`
+
+A powerful and convenient development tool for managing local clusters of FindoraNetwork.
+Its goal is to replace some existing rudimentary development environment management tools, such as: `make debug_env` and `make devnet`.
 
 ## User guide
 
-**TODO**
+Through a `fn dev -h` we can see:
+
+```shell
+fn-dev
+Manage development clusters on your localhost
+
+USAGE:
+    fn dev [OPTIONS] [SUBCOMMAND]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -e, --env-name <ENV NAME>    The name of the target env
+
+SUBCOMMANDS:
+    add-node       Attach a new node to an existing env
+    create         Create a new env
+    del-node       Pop a node from an existing env
+    destroy        Destroy an existing env
+    destroy-all    Destroy all existing ENVs
+    help           Prints this message or the help of the given subcommand(s)
+    info           Default operation, show the information of an existing env
+    info-all       Show the details of all existing ENVs
+    init           Config the initial settings(POS,FRA issuance...)
+    init-all       Apply the `init` operation to all existing ENVs
+    list           List the names of all existing ENVs
+    start          Start an existing env
+    stop           Stop an existing env
+```
+
+#### Management of a single cluster
+
+In the simplest scenario, similar to the functions of `make debug_env` and `make devnet`, we can:
+- create and start a single cluster(`fn dev create`)
+- stop the cluster(`fn dev stop`)
+- restart/start the cluster(`fn dev start`)
+- destroy the cluster(`fn dev destroy`)
+
+However, `fn dev` can do far more than these, let's show a typical usage flow.
+
+The first step, a new cluster need to be created by `fn dev create`, all configurations use default values, for example, the name of this ENV will be 'DEFAULT', the listening address of all nodes is '127.0.0.1', and so on.
+
+Now you can do some basic tests on this new cluster, for example, check the availability of some APIs you care about:
+- `curl 'localhost:8667/version'`
+- `curl 'localhost:26657/validators'`
+- ...
+
+Then you are very likely to execute a `fn dev init` operation to initilize the 'DEFAULT' cluster, after this, all necessary system settings will be done.
+
+Now the cluster can be considered to be a full-featured local network, you can:
+- transfer tokens
+- issue your custom tokens
+- do staking operations
+- do evm related operations
+- ...
+
+But wait, where can I get the FRA token? How to check the staking key of valiadtors? In a word, how to easily view these necessary information?
+
+Don't worry, a `fn dev info` will show you everything you need, you can use a shorter style `fn dev` when using the default cluster, they are equal.
+
+Below is the information of a custom ENV named 'MyEnv', `fn dev -e MyEnv`:
+```json
+{
+  "env_name": "MyEnv",
+  "env_home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv",
+  "host_ip": "192.168.2.5",
+  "bank_account": {
+    "wallet_address": "fra18xkez3fum44jq0zhvwq380rfme7u624cccn3z56fjeex6uuhpq6qv9e4g5",
+    "public_key": "Oa2RRTzdayA8V2OBE7xp3n3NKrjGJxFTSZZybXOXCDQ=",
+    "secret_key": "Ew9fMaryTL44ZXnEhcF7hQ-AB-fxgaC8vyCH-hCGtzg=",
+    "mnemonic_words": "field ranch pencil chest effort coyote april move injury illegal forest amount bid sound mixture use second pet embrace twice total essay valve loan"
+  },
+  "initial_validator_number": 3,
+  "initial_pos_settings": [
+    {
+      "tendermint_addr": "73BDBF3C63E04426253F865D35B4D2A49B14067C",
+      "tendermint_pubkey": "cnKgCfkSpQklo6zvrdsi51wGnUK+L14tkJ1UfFFcubQ=",
+      "xfr_keypair": {
+        "pub_key": "Y09bRu4S-zcJcRMZ53NS3aOEESnngSdyabhk3rMk1oc=",
+        "sec_key": "REHUN5f0P9jfSYINfrzYbfSEL_IcuJD77HEbcbZyIMY="
+      },
+      "xfr_mnemonic": "crumble girl fashion soccer output among decade blind close hen fish harbor lava peasant immense odor offer album shine train raccoon tired section drink",
+      "xfr_wallet_addr": "fra1vd84k3hwztanwzt3zvv7wu6jmk3cgyffu7qjwunfhpjdavey66rs6ae34u"
+    },
+    {
+      "tendermint_addr": "E3DA161A1A76355E3C6A6A28F91CC1C70F74C283",
+      "tendermint_pubkey": "88Cfkyw1nKrV34Gm0A72PZpShUrOidgpoRVeIqzefzk=",
+      "xfr_keypair": {
+        "pub_key": "HbEIkerMF6H8Ms4N3mB4hxkNuq6ME3ywjwOxenCdDcI=",
+        "sec_key": "iAmcC7giQV9QvPE2oSIALx3fVbSvrrkXydBLn3zubvE="
+      },
+      "xfr_mnemonic": "iron useful rebel critic spray banner history medal artist enough expect despair accident busy tilt sad cart digital vacant tomorrow tattoo outer noodle common",
+      "xfr_wallet_addr": "fra1rkcs3y02est6rlpjecxaucrcsuvsmw4w3sfhevy0qwch5uyaphpqnksdqw"
+    },
+    {
+      "tendermint_addr": "E6F78B1FC32EA8A37444DC6E003EE99660BA9EC7",
+      "tendermint_pubkey": "Ehcd16B30gs5+etbVCbjMVWDn/ELjhrP0SrJcmaR/yM=",
+      "xfr_keypair": {
+        "pub_key": "fYiR2ZjTwDCb1QDyqevGgEIilNCAwdoGUuzOL0tNE6s=",
+        "sec_key": "Jq-MrDCPGf0K0VH8rL5R1xb8E6oO9PAV1AyJI4z3-LY="
+      },
+      "xfr_mnemonic": "basic critic follow exhaust rigid worth sponsor chest boss unable bundle entire wife multiply hover miracle three fiber route student never apart during foam",
+      "xfr_wallet_addr": "fra10kyfrkvc60qrpx74qre2n67xsppz99xssrqa5pjjan8z7j6dzw4sl68y8v"
+    }
+  ],
+  "block_interval": 1,
+  "evm_chain_id": 777,
+  "checkpoint_file": "/tmp/checkpoint.toml",
+  "abcid_extra_flags": "--disable-eth-empty-blocks",
+  "seed_nodes": {
+    "0": {
+      "id": 0,
+      "tm_id": "6b2b1e45488c6314a8c91251716e36534fb591c8",
+      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/0",
+      "kind": "Seed",
+      "ports": {
+        "web3_http": 47633,
+        "web3_ws": 62803,
+        "tm_p2p": 21344,
+        "tm_rpc": 39048,
+        "app_abci": 22262,
+        "app_8669": 47168,
+        "app_8668": 28209
+      }
+    }
+  },
+  "validator_or_full_nodes": {
+    "1": {
+      "id": 1,
+      "tm_id": "5d09376ed2f37971181ad98e6e3b2d443580d6b9",
+      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/1",
+      "kind": "Node",
+      "ports": {
+        "web3_http": 25789,
+        "web3_ws": 20950,
+        "tm_p2p": 33684,
+        "tm_rpc": 64524,
+        "app_abci": 33266,
+        "app_8669": 22703,
+        "app_8668": 40368
+      }
+    },
+    "2": {
+      "id": 2,
+      "tm_id": "6424b547c11c146becee4c3d9f369dcfabff8ee5",
+      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/2",
+      "kind": "Node",
+      "ports": {
+        "web3_http": 20404,
+        "web3_ws": 55511,
+        "tm_p2p": 36443,
+        "tm_rpc": 54663,
+        "app_abci": 27465,
+        "app_8669": 32295,
+        "app_8668": 37006
+      }
+    },
+    "3": {
+      "id": 3,
+      "tm_id": "d2b7dc906d7295e1d787bfee81e49f7e7c64aa20",
+      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/3",
+      "kind": "Node",
+      "ports": {
+        "web3_http": 31594,
+        "web3_ws": 65203,
+        "tm_p2p": 62070,
+        "tm_rpc": 46755,
+        "app_abci": 21096,
+        "app_8669": 27923,
+        "app_8668": 51732
+      }
+    }
+  },
+  "tendermint_genesis_config": "{\"app_hash\":\"\",\"chain_id\":\"test-chain-SoyWN0\",\"consensus_params\":{\"block\":{\"max_bytes\":\"22020096\",\"max_gas\":\"-1\",\"time_iota_ms\":\"1000\"},\"evidence\":{\"max_age_duration\":\"172800000000000\",\"max_age_num_blocks\":\"100000\"},\"validator\":{\"pub_key_types\":[\"ed25519\"]}},\"genesis_time\":\"2022-09-05T16:43:57.400461512Z\",\"validators\":[{\"address\":\"E3DA161A1A76355E3C6A6A28F91CC1C70F74C283\",\"name\":\"node-0\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"88Cfkyw1nKrV34Gm0A72PZpShUrOidgpoRVeIqzefzk=\"},\"voting_power\":\"1\"},{\"address\":\"E6F78B1FC32EA8A37444DC6E003EE99660BA9EC7\",\"name\":\"node-1\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"Ehcd16B30gs5+etbVCbjMVWDn/ELjhrP0SrJcmaR/yM=\"},\"voting_power\":\"1\"},{\"address\":\"73BDBF3C63E04426253F865D35B4D2A49B14067C\",\"name\":\"node-2\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"cnKgCfkSpQklo6zvrdsi51wGnUK+L14tkJ1UfFFcubQ=\"},\"voting_power\":\"1\"}]}",
+  "next_node_id": 4
+}
+```
+
+You can pause the cluster by `fn dev stop`, and resume it by `fn dev start` at any time; you can also scale up the cluster by `fn dev add-node`, and scale it down by `fn dev del-node`.
+
+At last, if you don't need this cluster anymore, you can permanently destroy it with the `fn dev destroy` subcommand.
+
+The above is the simplest management process of a local development environment, which is enough for developers to self-debug on their localhosts.
+
+But obviously, for example, for the scenario of front-end and back-end joint debugging, the simplest cluster configuration above is not enough, so we need some additional configuration options to meet these requirements. Most of these additional configurations need to be specified during the cluster creation process, that is, specified in the scope of the `fn dev create` subcommand.
+
+Let's check the help information of `fn dev create`:
+```
+fn-dev-create
+Create a new env
+
+USAGE:
+    fn dev create [OPTIONS]
+
+FLAGS:
+    -h, --help       Prints help information
+    -V, --version    Prints version information
+
+OPTIONS:
+    -E, --abcid-extra-flags <ABCID EXTRA FLAGS>    A pair of quotes should be used when specifying extra flags
+    -i, --block-itv-secs <BLOCK INTERVAL>          Block interval in seconds
+    -c, --checkpoint-file <CHECKPOINT FILE>        The file path of the checkpoint file
+    -e, --env-name <ENV NAME>                      The name of the target env
+    -I, --evm-chain-id <EVM CHAIN ID>              The chain id in the scope of evm logic
+    -H, --host-ip <HOST IP>                        The IP of your local host, default to 127.0.0.1
+    -N, --validator-num <VALIDATOR NUMBER>         How many initial validators should be created
+```
+
+For the issue of remote joint debugging, we can use the `--host-ip` option to specify the listening address of the target ENV.
+
+A few other commonly used options:
+- `-i, --block-itv-secs`, block interval, default to 3s
+- `-c, --checkpoint-file`, the path of you custom checkpoint file
+- `-I, --evm-chain-id`, the value of this option will be defined as `${EVM_CHAIN_ID}`
+- `-N, --validator-num`, 5 initial validators will be created by default, you can change the number by this option
+- `-E, --abcid-extra-flags`, specify extra flags
+  - for example, there is a `--disable-eth-empty-blocks` flag in the `abcid` binary, and it will not be set by `fn dev` by default, you can set it like this `fn dev create -E '--disable-eth-empty-blocks'`
+
+Below is a more complete example with richer options:
+```shell
+fn dev create \
+    -H 192.168.2.5 \
+    -e MyEnv \
+    -i 1 \
+    -N 10 \
+    -I 777 \
+    -c /tmp/checkpoint.toml \
+    -E '--disable-eth-empty-blocks'
+```
+
+- all nodes of this ENV will listen on '192.168.2.5'
+  - now you can tell the IP address to your frond-end engineers, the joint debugging will be ok
+- the name of this ENV is 'MyEnv'
+- the block interval will be 1s
+- the number of initial validator nodes is 10
+- the chain id of evm is 777
+- the path of checkpoint file is '/tmp/checkpoint.toml'
+- `--disable-eth-empty-blocks` is added as an extra flag
+
+The coresponding starting commands of nodes will be(but in one-line style):
+```shell
+# cat /tmp/__FINDORA_DEV__/envs/MyEnv/3/fn_dev.log
+
+tendermint node \
+    --home /tmp/__FINDORA_DEV__/envs/MyEnv/3 \
+    >>/tmp/__FINDORA_DEV__/envs/MyEnv/3/tendermint.log 2>&1 &
+
+EVM_CHAIN_ID=777 FINDORA_BLOCK_ITV=1 \
+abcid --enable-query-service --enable-eth-api-service \
+    --tendermint-host 192.168.2.5 \
+    --tendermint-port 41043 \
+    --abcid-port 22480 \
+    --submission-service-port 61919 \
+    --ledger-service-port 61912 \
+    --evm-http-port 21536 \
+    --evm-ws-port 34983 \
+    --ledger-dir /tmp/__FINDORA_DEV__/envs/MyEnv/3/__findora__ \
+    --tendermint-node-key-config-path /tmp/__FINDORA_DEV__/envs/MyEnv/3/config/priv_validator_key.json \
+    --disable-eth-empty-blocks \
+    --checkpoint-file /tmp/checkpoint.toml \
+    >>/tmp/__FINDORA_DEV__/envs/MyEnv/3/app.log 2>&1 &
+```
+
+#### Management of multiple clusters
+
+Resource allocation and process running between different clusters are completely isolated, so managing multiple clusters, or in other words, managing custom clusters is not much different from the default cluster. The only difference is that you do not have to explicitly specify the env name when managing the default cluster, but for non-default clusters, all operations must explicitly specify the name of the target env.
+
+For example, for the default cluster, `fn dev stop` is equal to `fn dev stop -e DEFAULT`, both styles are ok; but there is only one style for a custom cluster, that is `fn dev stop -e YourCustomEnv`.
+
+Also, there are some subcommands designed specifically for multi-cluster management:
+- `fn dev list`, list the names of all existing ENVs
+- `fn dev info-all`, list the details of all existing ENVs
+- `fn dev init-all`, initilize all existing ENVs in batch mode
+- `fn dev destroy-all`, destroy all existing ENVs
+
+#### Environment variable definitions
+
+Currently no environment variables are defined inside `fn dev`.
+
+#### Internal organization of data and logs
+
+All data and logs are located under `/tmp/__FINDORA_DEV__`, so you should have a big enough `/tmp`.
+
+We can use `tree -F -L 2 /tmp/__FINDORA_DEV__` to check their structures:
+```
+/tmp/__FINDORA_DEV__/
+├── envs/               # existing ENVs
+│   ├── DEFAULT/        # the default ENV
+│   ├── env_A/          # a custom ENV named 'env_A'
+│   └── env_B/          # a custom ENV named 'env_B'
+└── ports_cache         # allocated ports
+```
+
+Let's check the inner structure of 'DEFAULT', `tree -F -L 1 /tmp/__FINDORA_DEV__/envs/DEFAULT`:
+```
+/tmp/__FINDORA_DEV__/envs/DEFAULT/
+├── 0/           # seed node of this ENV, can *not* be removed dynamicly
+├── 1/           # the first validator node of this ENV, can *not* be removed dynamicly
+├── 2/           # the second validator node of this ENV, can be removed dynamicly
+├── 3/           # the third validator node, similar with the second one
+├── 4/           # ...
+├── 5/           # ...
+└── config.json  # config file of this ENV
+```
+
+Then further check the internal structure of a node, `tree -F -L 1 /tmp/__FINDORA_DEV__/envs/DEFAULT/1`:
+
+```
+/tmp/__FINDORA_DEV__/envs/DEFAULT/1/
+├── config/              # config dir of the tendermint consensus engine
+├── data/                # data dir of the tendermint consensus engine
+├── tendermint.log       # log of the tendermint consensus engine
+├── __findora__/         # data of the 'abcid' process
+├── app.log              # log of the 'abcid' process
+└── fn_dev.log           # log of the 'fn dev' system
+```
+
+Inner management operations of `fn dev` will be logged in the `fn_dev.log` file.
 
 ## Compatibility Notes
 

--- a/src/components/finutils/src/common/dev/README.md
+++ b/src/components/finutils/src/common/dev/README.md
@@ -328,6 +328,10 @@ Inner management operations of `fn dev` will be logged in the `fn_dev.log` file.
 
 ## Compatibility Notes
 
+#### OS compatibility
+
+In theory, it can run well on most Linux and MacOS versions, but it is not suitable for Windows operating systems, and there is currently no compatibility plan for Windows.
+
 #### No breaks to musl compilation
 
 ```shell

--- a/src/components/finutils/src/common/dev/README.md
+++ b/src/components/finutils/src/common/dev/README.md
@@ -72,6 +72,8 @@ Below is the information of a custom ENV named 'MyEnv', `fn dev -e MyEnv`:
 {
   "env_name": "MyEnv",
   "env_home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv",
+  "tendermint_bin": "/tmp/tendermint-v0.33.8",
+  "abcid_bin": "/tmp/abcid-v0.4.0-preview",
   "host_ip": "192.168.2.5",
   "bank_account": {
     "wallet_address": "fra18xkez3fum44jq0zhvwq380rfme7u624cccn3z56fjeex6uuhpq6qv9e4g5",
@@ -79,39 +81,8 @@ Below is the information of a custom ENV named 'MyEnv', `fn dev -e MyEnv`:
     "secret_key": "Ew9fMaryTL44ZXnEhcF7hQ-AB-fxgaC8vyCH-hCGtzg=",
     "mnemonic_words": "field ranch pencil chest effort coyote april move injury illegal forest amount bid sound mixture use second pet embrace twice total essay valve loan"
   },
-  "initial_validator_number": 3,
-  "initial_pos_settings": [
-    {
-      "tendermint_addr": "73BDBF3C63E04426253F865D35B4D2A49B14067C",
-      "tendermint_pubkey": "cnKgCfkSpQklo6zvrdsi51wGnUK+L14tkJ1UfFFcubQ=",
-      "xfr_keypair": {
-        "pub_key": "Y09bRu4S-zcJcRMZ53NS3aOEESnngSdyabhk3rMk1oc=",
-        "sec_key": "REHUN5f0P9jfSYINfrzYbfSEL_IcuJD77HEbcbZyIMY="
-      },
-      "xfr_mnemonic": "crumble girl fashion soccer output among decade blind close hen fish harbor lava peasant immense odor offer album shine train raccoon tired section drink",
-      "xfr_wallet_addr": "fra1vd84k3hwztanwzt3zvv7wu6jmk3cgyffu7qjwunfhpjdavey66rs6ae34u"
-    },
-    {
-      "tendermint_addr": "E3DA161A1A76355E3C6A6A28F91CC1C70F74C283",
-      "tendermint_pubkey": "88Cfkyw1nKrV34Gm0A72PZpShUrOidgpoRVeIqzefzk=",
-      "xfr_keypair": {
-        "pub_key": "HbEIkerMF6H8Ms4N3mB4hxkNuq6ME3ywjwOxenCdDcI=",
-        "sec_key": "iAmcC7giQV9QvPE2oSIALx3fVbSvrrkXydBLn3zubvE="
-      },
-      "xfr_mnemonic": "iron useful rebel critic spray banner history medal artist enough expect despair accident busy tilt sad cart digital vacant tomorrow tattoo outer noodle common",
-      "xfr_wallet_addr": "fra1rkcs3y02est6rlpjecxaucrcsuvsmw4w3sfhevy0qwch5uyaphpqnksdqw"
-    },
-    {
-      "tendermint_addr": "E6F78B1FC32EA8A37444DC6E003EE99660BA9EC7",
-      "tendermint_pubkey": "Ehcd16B30gs5+etbVCbjMVWDn/ELjhrP0SrJcmaR/yM=",
-      "xfr_keypair": {
-        "pub_key": "fYiR2ZjTwDCb1QDyqevGgEIilNCAwdoGUuzOL0tNE6s=",
-        "sec_key": "Jq-MrDCPGf0K0VH8rL5R1xb8E6oO9PAV1AyJI4z3-LY="
-      },
-      "xfr_mnemonic": "basic critic follow exhaust rigid worth sponsor chest boss unable bundle entire wife multiply hover miracle three fiber route student never apart during foam",
-      "xfr_wallet_addr": "fra10kyfrkvc60qrpx74qre2n67xsppz99xssrqa5pjjan8z7j6dzw4sl68y8v"
-    }
-  ],
+  "initial_validator_number": 6,
+  "initial_pos_settings": [],
   "block_interval": 1,
   "evm_chain_id": 777,
   "checkpoint_file": "/tmp/checkpoint.toml",
@@ -119,69 +90,114 @@ Below is the information of a custom ENV named 'MyEnv', `fn dev -e MyEnv`:
   "seed_nodes": {
     "0": {
       "id": 0,
-      "tm_id": "6b2b1e45488c6314a8c91251716e36534fb591c8",
+      "tm_id": "7caec7b3a25c3966c6603452c9095a1e2ff19785",
       "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/0",
       "kind": "Seed",
       "ports": {
-        "web3_http": 47633,
-        "web3_ws": 62803,
-        "tm_p2p": 21344,
-        "tm_rpc": 39048,
-        "app_abci": 22262,
-        "app_8669": 47168,
-        "app_8668": 28209
+        "web3_http": 44752,
+        "web3_ws": 30047,
+        "tm_p2p": 37377,
+        "tm_rpc": 23863,
+        "app_abci": 42327,
+        "app_8669": 39832,
+        "app_8668": 45102
       }
     }
   },
   "validator_or_full_nodes": {
     "1": {
       "id": 1,
-      "tm_id": "5d09376ed2f37971181ad98e6e3b2d443580d6b9",
+      "tm_id": "bb81551e737b232285ecd563c499ba56a9335ed8",
       "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/1",
       "kind": "Node",
       "ports": {
-        "web3_http": 25789,
-        "web3_ws": 20950,
-        "tm_p2p": 33684,
-        "tm_rpc": 64524,
-        "app_abci": 33266,
-        "app_8669": 22703,
-        "app_8668": 40368
+        "web3_http": 39118,
+        "web3_ws": 38781,
+        "tm_p2p": 43052,
+        "tm_rpc": 52559,
+        "app_abci": 32767,
+        "app_8669": 45090,
+        "app_8668": 58272
       }
     },
     "2": {
       "id": 2,
-      "tm_id": "6424b547c11c146becee4c3d9f369dcfabff8ee5",
+      "tm_id": "25af74b05bd5a312f64ef2155ad2844e87cbf1a4",
       "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/2",
       "kind": "Node",
       "ports": {
-        "web3_http": 20404,
-        "web3_ws": 55511,
-        "tm_p2p": 36443,
-        "tm_rpc": 54663,
-        "app_abci": 27465,
-        "app_8669": 32295,
-        "app_8668": 37006
+        "web3_http": 30247,
+        "web3_ws": 30301,
+        "tm_p2p": 62187,
+        "tm_rpc": 34517,
+        "app_abci": 59392,
+        "app_8669": 39727,
+        "app_8668": 42059
       }
     },
     "3": {
       "id": 3,
-      "tm_id": "d2b7dc906d7295e1d787bfee81e49f7e7c64aa20",
+      "tm_id": "03eac7c59230e345cfc0a030dbd2c1bad003c75c",
       "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/3",
       "kind": "Node",
       "ports": {
-        "web3_http": 31594,
-        "web3_ws": 65203,
-        "tm_p2p": 62070,
-        "tm_rpc": 46755,
-        "app_abci": 21096,
-        "app_8669": 27923,
-        "app_8668": 51732
+        "web3_http": 62442,
+        "web3_ws": 34670,
+        "tm_p2p": 33516,
+        "tm_rpc": 40108,
+        "app_abci": 62630,
+        "app_8669": 61792,
+        "app_8668": 41703
+      }
+    },
+    "4": {
+      "id": 4,
+      "tm_id": "0892a3c97b664ea35c6f7815b0dc20699a0b2a13",
+      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/4",
+      "kind": "Node",
+      "ports": {
+        "web3_http": 25335,
+        "web3_ws": 30296,
+        "tm_p2p": 21710,
+        "tm_rpc": 49938,
+        "app_abci": 33458,
+        "app_8669": 42395,
+        "app_8668": 23640
+      }
+    },
+    "5": {
+      "id": 5,
+      "tm_id": "0a184e1f6faddb86cbf42940a739345965021dbe",
+      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/5",
+      "kind": "Node",
+      "ports": {
+        "web3_http": 38777,
+        "web3_ws": 64178,
+        "tm_p2p": 34144,
+        "tm_rpc": 36390,
+        "app_abci": 30303,
+        "app_8669": 32079,
+        "app_8668": 24219
+      }
+    },
+    "6": {
+      "id": 6,
+      "tm_id": "7bf456af4aa2ae6e933876d2da62a5e6109a141e",
+      "home": "/tmp/__FINDORA_DEV__/envs/MyEnv/6",
+      "kind": "Node",
+      "ports": {
+        "web3_http": 22716,
+        "web3_ws": 22631,
+        "tm_p2p": 47611,
+        "tm_rpc": 57745,
+        "app_abci": 26842,
+        "app_8669": 40852,
+        "app_8668": 54885
       }
     }
   },
-  "tendermint_genesis_config": "{\"app_hash\":\"\",\"chain_id\":\"test-chain-SoyWN0\",\"consensus_params\":{\"block\":{\"max_bytes\":\"22020096\",\"max_gas\":\"-1\",\"time_iota_ms\":\"1000\"},\"evidence\":{\"max_age_duration\":\"172800000000000\",\"max_age_num_blocks\":\"100000\"},\"validator\":{\"pub_key_types\":[\"ed25519\"]}},\"genesis_time\":\"2022-09-05T16:43:57.400461512Z\",\"validators\":[{\"address\":\"E3DA161A1A76355E3C6A6A28F91CC1C70F74C283\",\"name\":\"node-0\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"88Cfkyw1nKrV34Gm0A72PZpShUrOidgpoRVeIqzefzk=\"},\"voting_power\":\"1\"},{\"address\":\"E6F78B1FC32EA8A37444DC6E003EE99660BA9EC7\",\"name\":\"node-1\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"Ehcd16B30gs5+etbVCbjMVWDn/ELjhrP0SrJcmaR/yM=\"},\"voting_power\":\"1\"},{\"address\":\"73BDBF3C63E04426253F865D35B4D2A49B14067C\",\"name\":\"node-2\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"cnKgCfkSpQklo6zvrdsi51wGnUK+L14tkJ1UfFFcubQ=\"},\"voting_power\":\"1\"}]}",
-  "next_node_id": 4
+  "tendermint_genesis_config": "{\"app_hash\":\"\",\"chain_id\":\"test-chain-zfWF7p\",\"consensus_params\":{\"block\":{\"max_bytes\":\"22020096\",\"max_gas\":\"-1\",\"time_iota_ms\":\"1000\"},\"evidence\":{\"max_age_duration\":\"172800000000000\",\"max_age_num_blocks\":\"100000\"},\"validator\":{\"pub_key_types\":[\"ed25519\"]}},\"genesis_time\":\"2022-09-05T18:11:48.125514813Z\",\"validators\":[{\"address\":\"1EC4D45D32369471CFC2D72BA13BBC763F8F7F01\",\"name\":\"node-0\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"1JLCxVB57o6O0kvKO4SqcxnVbbiyy8cOFJZ6VaXNPRE=\"},\"voting_power\":\"1\"},{\"address\":\"7860BD6D1E825C0BD64E58CAAF007028F22EB6EF\",\"name\":\"node-1\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"34JI8V8j/z4wT9MRtpZF3AtNdJxwt8guQfn4lhdnLUM=\"},\"voting_power\":\"1\"},{\"address\":\"AD1EE8FCCB2D69C2FD0E038DA431B0A0264B1F2D\",\"name\":\"node-2\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"ajDU9S6SMwkBtvIyJ838CuGDLq+MN6ZUFjWfRAY2rp4=\"},\"voting_power\":\"1\"},{\"address\":\"860FCA9E795E1982BEAC75F7DBF1A8E55D82749C\",\"name\":\"node-3\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"MJm6lkkwW2ZYd2Z1QTwAK5eLPvmzcFpYAi+PN4XthJ0=\"},\"voting_power\":\"1\"},{\"address\":\"19272E9A28AE77D81A2B2768F1C2B9EA75AC8670\",\"name\":\"node-4\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"3yyNXD503Fctiwmbw8JTk2jdZBDA2Drm9CkSw/VCTvo=\"},\"voting_power\":\"1\"},{\"address\":\"078E2E0F813C3B92032812E6E87A2D3262A55A2C\",\"name\":\"node-5\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"Ygg2h6SAsNSud/PsGSiJ86KjXdeeUa+dqiV4zGPcDok=\"},\"voting_power\":\"1\"}]}",
+  "next_node_id": 7
 }
 ```
 
@@ -235,7 +251,7 @@ fn dev create \
     -H 192.168.2.5 \
     -e MyEnv \
     -i 1 \
-    -N 10 \
+    -N 6 \
     -I 777 \
     -c /tmp/checkpoint.toml \
     -T /tmp/tendermint-v0.33.8 \
@@ -247,7 +263,7 @@ fn dev create \
   - now you can tell the IP address to your frond-end engineers, the joint debugging will be ok
 - the name of this ENV is 'MyEnv'
 - the block interval will be 1s
-- the number of initial validator nodes is 10
+- the number of initial validator nodes is 6
 - the chain id of evm is 777
 - the path of checkpoint file is '/tmp/checkpoint.toml'
 - use custom binaries of tendermint and abcid
@@ -257,12 +273,12 @@ The coresponding starting commands of nodes will be(but in one-line style):
 ```shell
 # cat /tmp/__FINDORA_DEV__/envs/MyEnv/3/fn_dev.log
 
-tendermint node \
+/tmp/tendermint-v0.33.8 node \
     --home /tmp/__FINDORA_DEV__/envs/MyEnv/3 \
     >>/tmp/__FINDORA_DEV__/envs/MyEnv/3/tendermint.log 2>&1 &
 
 EVM_CHAIN_ID=777 FINDORA_BLOCK_ITV=1 \
-abcid --enable-query-service --enable-eth-api-service \
+/tmp/abcid-v0.4.0-preview --enable-query-service --enable-eth-api-service \
     --tendermint-host 192.168.2.5 \
     --tendermint-port 41043 \
     --abcid-port 22480 \
@@ -279,7 +295,11 @@ abcid --enable-query-service --enable-eth-api-service \
 
 #### Management of multiple clusters
 
-Resource allocation and process running between different clusters are completely isolated, so managing multiple clusters, or in other words, managing custom clusters is not much different from the default cluster. The only difference is that you do not have to explicitly specify the env name when managing the default cluster, but for non-default clusters, all operations must explicitly specify the name of the target env.
+Since each cluster can specify its own executing binaries(tendermint & abcid), the multi-cluster mode is of great significance for functional comparison, testing and problem debugging between different versions or between different features.
+
+Managing multiple clusters, or in other words, managing custom clusters is not much different from the default cluster because resource allocation and process running between different clusters are completely isolated in `fn dev`.
+
+The only difference is that you do not have to explicitly specify the env name when managing the default cluster, but for non-default clusters, all operations must explicitly specify the name of the target env.
 
 For example, for the default cluster, `fn dev stop` is equal to `fn dev stop -e DEFAULT`, both styles are ok; but there is only one style for a custom cluster, that is `fn dev stop -e YourCustomEnv`.
 

--- a/src/components/finutils/src/common/dev/README.md
+++ b/src/components/finutils/src/common/dev/README.md
@@ -206,13 +206,15 @@ FLAGS:
     -V, --version    Prints version information
 
 OPTIONS:
-    -E, --abcid-extra-flags <ABCID EXTRA FLAGS>    A pair of quotes should be used when specifying extra flags
-    -i, --block-itv-secs <BLOCK INTERVAL>          Block interval in seconds
-    -c, --checkpoint-file <CHECKPOINT FILE>        The file path of the checkpoint file
-    -e, --env-name <ENV NAME>                      The name of the target env
-    -I, --evm-chain-id <EVM CHAIN ID>              The chain id in the scope of evm logic
-    -H, --host-ip <HOST IP>                        The IP of your local host, default to 127.0.0.1
-    -N, --validator-num <VALIDATOR NUMBER>         How many initial validators should be created
+    -A, --abcid-bin-path <ABCID BIN PATH>              The path of your custom abcid binary
+    -E, --abcid-extra-flags <ABCID EXTRA FLAGS>        A pair of quotes should be used when specifying extra flags
+    -i, --block-itv-secs <BLOCK INTERVAL>              Block interval in seconds
+    -c, --checkpoint-file <CHECKPOINT FILE>            The file path of the checkpoint file
+    -e, --env-name <ENV NAME>                          The name of the target env
+    -I, --evm-chain-id <EVM CHAIN ID>                  The chain id in the scope of evm logic
+    -H, --host-ip <HOST IP>                            The IP of your local host, default to 127.0.0.1
+    -T, --tendermint-bin-path <TENDERMINT BIN PATH>    The path of your custom tendermint binary
+    -N, --validator-num <VALIDATOR NUMBER>             How many initial validators should be created
 ```
 
 For the issue of remote joint debugging, we can use the `--host-ip` option to specify the listening address of the target ENV.
@@ -222,6 +224,8 @@ A few other commonly used options:
 - `-c, --checkpoint-file`, the path of you custom checkpoint file
 - `-I, --evm-chain-id`, the value of this option will be defined as `${EVM_CHAIN_ID}`
 - `-N, --validator-num`, 5 initial validators will be created by default, you can change the number by this option
+- `-T, --tendermint-bin-path`, use a custom version of the tendermint binary
+- `-A, --abcid-bin-path`, use a custom versioln of the abcid binary
 - `-E, --abcid-extra-flags`, specify extra flags
   - for example, there is a `--disable-eth-empty-blocks` flag in the `abcid` binary, and it will not be set by `fn dev` by default, you can set it like this `fn dev create -E '--disable-eth-empty-blocks'`
 
@@ -234,6 +238,8 @@ fn dev create \
     -N 10 \
     -I 777 \
     -c /tmp/checkpoint.toml \
+    -T /tmp/tendermint-v0.33.8 \
+    -A /tmp/abcid-v0.4.0-preview \
     -E '--disable-eth-empty-blocks'
 ```
 
@@ -244,6 +250,7 @@ fn dev create \
 - the number of initial validator nodes is 10
 - the chain id of evm is 777
 - the path of checkpoint file is '/tmp/checkpoint.toml'
+- use custom binaries of tendermint and abcid
 - `--disable-eth-empty-blocks` is added as an extra flag
 
 The coresponding starting commands of nodes will be(but in one-line style):

--- a/src/components/finutils/src/common/dev/init.rs
+++ b/src/components/finutils/src/common/dev/init.rs
@@ -81,12 +81,15 @@ pub fn init(env: &mut Env) -> Result<()> {
         serde_json::from_str::<XfrSecretKey>(&format!("\"{}\"", BANK_ACCOUNT_SECKEY))
             .c(d!())?
             .into_keypair();
-    println!(">>> Block interval: {} seconds", env.block_itv_secs);
+    println!(
+        "[ {} ] >>> Block interval: {} seconds",
+        &env.name, env.block_itv_secs
+    );
 
-    println!(">>> Define and issue FRA ...");
+    println!("[ {} ] >>> Define and issue FRA ...", &env.name);
     send_tx(env, &fra_gen_initial_tx(&root_kp)).c(d!())?;
 
-    println!(">>> Wait 2 block ...");
+    println!("[ {} ] >>> Wait 2 block ...", &env.name);
     sleep_n_block!(2);
 
     let target_list = env
@@ -95,13 +98,13 @@ pub fn init(env: &mut Env) -> Result<()> {
         .map(|v| (v.xfr_keypair.get_pk_ref(), 500_0000 * FRA))
         .collect::<Vec<_>>();
 
-    println!(">>> Transfer FRAs to validators ...");
+    println!("[ {} ] >>> Transfer FRAs to validators ...", &env.name);
     transfer_batch(env, &root_kp, target_list, None, true, true).c(d!())?;
 
-    println!(">>> Wait 2 block ...");
+    println!("[ {} ] >>> Wait 2 block ...", &env.name);
     sleep_n_block!(2);
 
-    println!(">>> Propose self-delegations ...");
+    println!("[ {} ] >>> Propose self-delegations ...", &env.name);
     for (i, v) in env.initial_validators.iter().enumerate() {
         let mut builder = new_tx_builder(env).c(d!())?;
         let am = (400_0000 + i as u64 * 1_0000) * FRA;
@@ -129,7 +132,7 @@ pub fn init(env: &mut Env) -> Result<()> {
         send_tx(env, &tx).c(d!())?;
     }
 
-    println!(">>> Init work done !");
+    println!("[ {} ] >>> Init work done !", &env.name);
     Ok(())
 }
 

--- a/src/components/finutils/src/common/dev/mod.rs
+++ b/src/components/finutils/src/common/dev/mod.rs
@@ -759,9 +759,12 @@ impl TryFrom<&InitialValidator> for StakingValidator {
 #[derive(Debug, Clone, Deserialize, Serialize)]
 struct Node {
     id: NodeId,
+    #[serde(rename = "tendermint_node_id")]
     tm_id: String,
+    #[serde(rename = "home_dir")]
     home: String,
     kind: Kind,
+    #[serde(rename = "occupied_ports")]
     ports: Ports,
 }
 
@@ -883,6 +886,7 @@ impl Node {
 
 #[derive(Debug, Clone, Copy, Deserialize, Serialize)]
 enum Kind {
+    #[serde(rename = "ValidatorOrFull")]
     Node,
     Seed,
 }
@@ -890,12 +894,19 @@ enum Kind {
 // Active ports of a node
 #[derive(Default, Debug, Clone, Deserialize, Serialize)]
 struct Ports {
+    #[serde(rename = "web3_http_service")]
     web3_http: u16,
+    #[serde(rename = "web3_websocket_service")]
     web3_ws: u16,
+    #[serde(rename = "tendermint_p2p_service")]
     tm_p2p: u16,
+    #[serde(rename = "tendermint_rpc_service")]
     tm_rpc: u16,
+    #[serde(rename = "abcid_abci_service")]
     app_abci: u16,
+    #[serde(rename = "abcid_submission_service")]
     app_8669: u16,
+    #[serde(rename = "abcid_ledger_query_service")]
     app_8668: u16,
 }
 

--- a/src/components/finutils/src/common/dev/mod.rs
+++ b/src/components/finutils/src/common/dev/mod.rs
@@ -174,6 +174,7 @@ pub struct Env {
     // validator informations related to POS
     #[serde(rename = "initial_validator_number")]
     initial_validator_num: u8,
+
     #[serde(rename = "initial_pos_settings")]
     initial_validators: Vec<InitialValidator>,
 
@@ -195,15 +196,16 @@ pub struct Env {
 
     #[serde(rename = "seed_nodes")]
     seeds: BTreeMap<NodeId, Node>,
+
     #[serde(rename = "validator_or_full_nodes")]
     nodes: BTreeMap<NodeId, Node>,
+
+    // the latest/max id of current nodes
+    next_node_id: NodeId,
 
     // the contents of `genesis.json` of all nodes
     #[serde(rename = "tendermint_genesis_config")]
     genesis: String,
-
-    // the latest/max id of current nodes
-    next_node_id: NodeId,
 }
 
 impl Env {
@@ -823,7 +825,7 @@ impl Node {
                 )
                 .unwrap();
 
-                pnk!(self.write_cmd_log(&cmd));
+                pnk!(self.write_fn_log(&cmd));
                 pnk!(exec_spawn(&cmd));
 
                 exit(0);
@@ -847,10 +849,10 @@ impl Node {
         );
         let outputs = cmd::exec_output(&cmd).c(d!())?;
         let contents = format!("{}\n{}", &cmd, outputs.as_str());
-        self.write_cmd_log(&contents).c(d!())
+        self.write_fn_log(&contents).c(d!())
     }
 
-    fn write_cmd_log(&self, cmd: &str) -> Result<()> {
+    fn write_fn_log(&self, cmd: &str) -> Result<()> {
         OpenOptions::new()
             .read(true)
             .write(true)

--- a/src/ledger/src/staking/mod.rs
+++ b/src/ledger/src/staking/mod.rs
@@ -165,8 +165,16 @@ pub const MAX_TOTAL_POWER: Amount = Amount::MAX / 8;
 /// can not exceed 20% of global power.
 pub const MAX_POWER_PERCENT_PER_VALIDATOR: [u128; 2] = [1, 5];
 
-/// Block time interval, in seconds.
-pub const BLOCK_INTERVAL: u64 = 15 + 1;
+lazy_static! {
+    /// Block time interval, in seconds.
+    pub static ref BLOCK_INTERVAL: u64 = {
+        1 + env::var("FINDORA_BLOCK_ITV")
+            .ok()
+            .as_deref()
+            .unwrap_or("15")
+            .parse::<u64>().unwrap()
+    };
+}
 
 /// The lock time after the delegation expires, about 21 days.
 //pub const UNBOND_BLOCK_CNT: u64 = 3600 * 24 * 21 / BLOCK_INTERVAL;
@@ -2236,7 +2244,7 @@ fn calculate_delegation_rewards(
         let am = BigUint::from(amount);
         let total_am = BigUint::from(total_amount);
         let global_am = BigUint::from(global_amount);
-        let block_itv = BLOCK_INTERVAL as u128;
+        let block_itv = *BLOCK_INTERVAL as u128;
 
         let second_per_year: u128 = if CFG.checkpoint.second_fix_height < cur_height {
             365 * 24 * 3600
@@ -2271,7 +2279,7 @@ fn calculate_delegation_rewards(
         let am = amount as u128;
         let total_am = total_amount as u128;
         let global_am = global_amount as u128;
-        let block_itv = BLOCK_INTERVAL as u128;
+        let block_itv = *BLOCK_INTERVAL as u128;
 
         let calculate_self_only = || {
             am.checked_mul(return_rate[0])


### PR DESCRIPTION
> https://github.com/rust-util-collections/platform/blob/main/src/components/finutils/src/common/dev/README.md
> would like to act as an upgrade page for https://wiki.findora.org/docs/developers/development_network.
>
> SEE ALSO: https://github.com/FindoraNetwork/findora-wiki/pull/224

# `fn dev`

A powerful and convenient development tool for managing local clusters of FindoraNetwork.
Its goal is to replace some existing rudimentary development environment management tools, such as: `make debug_env` and `make devnet`.

## User guide

Through a `fn dev -h` we can see:

```shell
fn-dev
Manage development clusters on your localhost

USAGE:
    fn dev [OPTIONS] [SUBCOMMAND]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -e, --env-name <ENV NAME>    The name of the target env

SUBCOMMANDS:
    add-node       Attach a new node to an existing env
    create         Create a new env
    del-node       Pop a node from an existing env
    destroy        Destroy an existing env
    destroy-all    Destroy all existing ENVs
    help           Prints this message or the help of the given subcommand(s)
    info           Default operation, show the information of an existing env
    info-all       Show the details of all existing ENVs
    init           Config the initial settings(POS,FRA issuance...)
    init-all       Apply the `init` operation to all existing ENVs
    list           List the names of all existing ENVs
    start          Start an existing env
    stop           Stop an existing env
```

#### Management of a single cluster

In the simplest scenario, similar to the functions of `make debug_env` and `make devnet`, we can:
- create and start a single cluster(`fn dev create`)
- stop the cluster(`fn dev stop`)
- restart/start the cluster(`fn dev start`)
- destroy the cluster(`fn dev destroy`)

However, `fn dev` can do far more than these, let's show a typical usage flow.

The first step, a new cluster need to be created by `fn dev create`, all configurations use default values, for example, the name of this ENV will be 'DEFAULT', the listening address of all nodes is '127.0.0.1', and so on.

Now you can do some basic tests on this new cluster, for example, check the availability of some APIs you care about:
- `curl 'localhost:8667/version'`
- `curl 'localhost:26657/validators'`
- ...

Then you are very likely to execute a `fn dev init` operation to initilize the 'DEFAULT' cluster, after this, all necessary system settings will be done.

Now the cluster can be considered to be a full-featured local network, you can:
- transfer tokens
- issue your custom tokens
- do staking operations
- do evm related operations
- ...

But wait, where can I get the FRA token? How to check the staking key of valiadtors? In a word, how to easily view these necessary information?

Don't worry, a `fn dev info` will show you everything you need, you can use a shorter style `fn dev` when using the default cluster, they are equal.

Below is the information of a custom ENV named 'MyEnv', `fn dev -e MyEnv`:
```json
{
  "env_name": "MyEnv",
  "env_home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv",
  "tendermint_bin": "/tmp/tendermint-v0.33.8",
  "abcid_bin": "/tmp/abcid-v0.4.0-preview",
  "host_ip": "192.168.2.5",
  "bank_account": {
    "wallet_address": "fra18xkez3fum44jq0zhvwq380rfme7u624cccn3z56fjeex6uuhpq6qv9e4g5",
    "public_key": "Oa2RRTzdayA8V2OBE7xp3n3NKrjGJxFTSZZybXOXCDQ=",
    "secret_key": "Ew9fMaryTL44ZXnEhcF7hQ-AB-fxgaC8vyCH-hCGtzg=",
    "mnemonic_words": "field ranch pencil chest effort coyote april move injury illegal forest amount bid sound mixture use second pet embrace twice total essay valve loan"
  },
  "initial_validator_number": 6,
  "initial_pos_settings": [
    {
      "tendermint_addr": "27055305231CF6F718AD26485499B3ED1CCC8115",
      "tendermint_pubkey": "MVQUuYdJzxmYiJnmffxf40jBXXkwwnkLzt0f4XV+NeQ=",
      "xfr_keypair": {
        "pub_key": "5vy5t4sG_cbLVJvKQWn7xwd7WSmRQlUX6KW-IvDTLBo=",
        "sec_key": "fCBBCZCh8-IxCn9rgjoRiX03_SiuI99EouM-VJ9Hu5U="
      },
      "xfr_mnemonic": "chat fish hedgehog step help waste charge repeat cram public address visa around iron sponsor silly obvious sail squirrel relief arrive pet toe nominee",
      "xfr_wallet_addr": "fra1um7tndutqm7udj65n09yz60mcurhkkffj9p929lg5klz9uxn9sdqlv3f2e"
    },
    {
      "tendermint_addr": "33A24EF38E695529EED806CF70751C2CFC61DEAC",
      "tendermint_pubkey": "bvjpaBraL50Q8rRo+a7HH5HU2YI4lEasxm5CrP/TC6c=",
      "xfr_keypair": {
        "pub_key": "MOm22HEhE59rIb9H2Vgg_-Y0EOaIolKUbGcWXdfyZdM=",
        "sec_key": "AVj4I7G85a_dpETRjZbEYAlAiP7kBGxUx-3YBmYfhDc="
      },
      "xfr_mnemonic": "inject clerk accuse crunch absurd piece rely property bird win cave occur panther shaft switch device ketchup amused rather tragic settle celery dose brick",
      "xfr_wallet_addr": "fra1xr5mdkr3yyfe76epharajkpqllnrgy8x3z3999rvvut9m4ljvhfsjf5375"
    },
    {
      "tendermint_addr": "38AD0AF0258FB751262BD9D835A4D7848B0BC60E",
      "tendermint_pubkey": "5UzQOmtN9xT7kOLq9w0B4UA1U5dUeuJgzItbGkdepvg=",
      "xfr_keypair": {
        "pub_key": "zH51NYSEam0rA8aJTFlyxHY-t3KFAg9uTnZ47l0HTCI=",
        "sec_key": "S-WS-_maS1beU8fKBpTKBXUzZ8i1-9q44MlXYFiddak="
      },
      "xfr_mnemonic": "repeat noise rare rely open crucial awkward firm distance about detect connect style device wagon level check grow bench year toddler rubber sense advice",
      "xfr_wallet_addr": "fra1e3l82dvys34x62crc6y5cktjc3mradmjs5pq7mjwweuwuhg8fs3qpwjk0r"
    },
    {
      "tendermint_addr": "4F850CA6849EC0B3FC808D912F35CE2DAA222006",
      "tendermint_pubkey": "l+7AqB4df3ckzpF+7Ku4xh9z+WPzhyzjw99WKE0K9oI=",
      "xfr_keypair": {
        "pub_key": "RyqsOAAqHeEGW2AKwywDX7GgOTP5XjMfAnYlufOKmIM=",
        "sec_key": "CvaTBun0MiEeSErqHMPKRih0ADIu_UUjzuFQ2zdekuw="
      },
      "xfr_mnemonic": "harbor all speed train adult alien box steel promote discover desk antique please ship total carry coral deer method nominee blanket ghost brand have",
      "xfr_wallet_addr": "fra1gu42cwqq9gw7zpjmvq9vxtqrt7c6qwfnl90rx8czwcjmnuu2nzpsmg9205"
    },
    {
      "tendermint_addr": "C81783A1C67AD00C82FF093CE36AFF938185E44B",
      "tendermint_pubkey": "QPh4cyJnFKpDwDbU0C30hoQfqwvjCN9xDB8OtomhMkE=",
      "xfr_keypair": {
        "pub_key": "THNbrDo9hoWDCJKePWhFG3KWDhK7Hd76-envNmOLmOM=",
        "sec_key": "inIf4M_Pr_9O845CCp_BvMakx-lnjFaNPTvRUMSFv3E="
      },
      "xfr_mnemonic": "cricket know material crop wheel merge imitate script sing pioneer honey safe access inquiry wall best sign seed hybrid helmet wheat grocery stone west",
      "xfr_wallet_addr": "fra1f3e4htp68krgtqcgj20r66z9rdefvrsjhvwaa7hea8hnvcutnr3spzuwm3"
    },
    {
      "tendermint_addr": "FAD1E8BBC00835B88FAA41B54EAA0D2FCE55FEF0",
      "tendermint_pubkey": "i3QFHggYCqG6ciKmsjAXSt6NKfyUOGjfje5YwYaYOfo=",
      "xfr_keypair": {
        "pub_key": "UtKUdsJTYLCbmAXUAWGb97zMyW0HvyADxsrz7T4vmG0=",
        "sec_key": "o9aYwKN27PC3OPa7GqDpvP5q5WPoJk-qjRp4KTgNeok="
      },
      "xfr_mnemonic": "fever cheap upper flash team language town sudden cash nurse orphan dove nation possible bracket coil hello orchard hurdle feature excuse rigid flee basic",
      "xfr_wallet_addr": "fra12tffgakz2dstpxucqh2qzcvm777vejtdq7ljqq7xete76030npks7w80ku"
    }
  ],
  "block_interval": 1,
  "evm_chain_id": 777,
  "checkpoint_file": "/tmp/checkpoint.toml",
  "abcid_extra_flags": "--disable-eth-empty-blocks",
  "seed_nodes": {
    "0": {
      "id": 0,
      "tendermint_node_id": "91a4fa7b110d051bf9bc832622afb41d97f27997",
      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/0",
      "kind": "Seed",
      "occupied_ports": {
        "web3_http_service": 27411,
        "web3_websocket_service": 24958,
        "tendermint_p2p_service": 32670,
        "tendermint_rpc_service": 56727,
        "abcid_abci_service": 56761,
        "abcid_submission_service": 20372,
        "abcid_ledger_query_service": 30015
      }
    }
  },
  "validator_or_full_nodes": {
    "1": {
      "id": 1,
      "tendermint_node_id": "4d4cdfb807697b680bffcf8cfbb6f90c43d60884",
      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/1",
      "kind": "ValidatorOrFull",
      "occupied_ports": {
        "web3_http_service": 29062,
        "web3_websocket_service": 34909,
        "tendermint_p2p_service": 46897,
        "tendermint_rpc_service": 30160,
        "abcid_abci_service": 40160,
        "abcid_submission_service": 58302,
        "abcid_ledger_query_service": 38985
      }
    },
    "2": {
      "id": 2,
      "tendermint_node_id": "4b66d6e9e8e8e9277afda3024eda5474690f68aa",
      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/2",
      "kind": "ValidatorOrFull",
      "occupied_ports": {
        "web3_http_service": 28888,
        "web3_websocket_service": 31504,
        "tendermint_p2p_service": 34962,
        "tendermint_rpc_service": 25973,
        "abcid_abci_service": 37529,
        "abcid_submission_service": 39327,
        "abcid_ledger_query_service": 33283
      }
    },
    "3": {
      "id": 3,
      "tendermint_node_id": "ef3e3dddeb5955efc8ef4905184008a28e4482b7",
      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/3",
      "kind": "ValidatorOrFull",
      "occupied_ports": {
        "web3_http_service": 46711,
        "web3_websocket_service": 31297,
        "tendermint_p2p_service": 56883,
        "tendermint_rpc_service": 52160,
        "abcid_abci_service": 39108,
        "abcid_submission_service": 26479,
        "abcid_ledger_query_service": 56173
      }
    },
    "4": {
      "id": 4,
      "tendermint_node_id": "cc55016ba689320bbdb95d5922fc14d02716119e",
      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/4",
      "kind": "ValidatorOrFull",
      "occupied_ports": {
        "web3_http_service": 29555,
        "web3_websocket_service": 34764,
        "tendermint_p2p_service": 28830,
        "tendermint_rpc_service": 33124,
        "abcid_abci_service": 22525,
        "abcid_submission_service": 26205,
        "abcid_ledger_query_service": 25639
      }
    },
    "5": {
      "id": 5,
      "tendermint_node_id": "ba1cdbbf61b59520f01ee6769777edc0a4af8a07",
      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/5",
      "kind": "ValidatorOrFull",
      "occupied_ports": {
        "web3_http_service": 55174,
        "web3_websocket_service": 57460,
        "tendermint_p2p_service": 47144,
        "tendermint_rpc_service": 48775,
        "abcid_abci_service": 29531,
        "abcid_submission_service": 46879,
        "abcid_ledger_query_service": 49426
      }
    },
    "6": {
      "id": 6,
      "tendermint_node_id": "bda665baeb0a82c8e9892358fe082dd1ead5ff2a",
      "home_dir": "/tmp/__FINDORA_DEV__/envs/MyEnv/6",
      "kind": "ValidatorOrFull",
      "occupied_ports": {
        "web3_http_service": 46340,
        "web3_websocket_service": 64310,
        "tendermint_p2p_service": 24224,
        "tendermint_rpc_service": 23894,
        "abcid_abci_service": 41878,
        "abcid_submission_service": 50118,
        "abcid_ledger_query_service": 31215
      }
    }
  },
  "tendermint_genesis_config": "{\"app_hash\":\"\",\"chain_id\":\"test-chain-wfnI4D\",\"consensus_params\":{\"block\":{\"max_bytes\":\"22020096\",\"max_gas\":\"-1\",\"time_iota_ms\":\"1000\"},\"evidence\":{\"max_age_duration\":\"172800000000000\",\"max_age_num_blocks\":\"100000\"},\"validator\":{\"pub_key_types\":[\"ed25519\"]}},\"genesis_time\":\"2022-09-06T01:25:39.871204204Z\",\"validators\":[{\"address\":\"38AD0AF0258FB751262BD9D835A4D7848B0BC60E\",\"name\":\"node-0\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"5UzQOmtN9xT7kOLq9w0B4UA1U5dUeuJgzItbGkdepvg=\"},\"voting_power\":\"1\"},{\"address\":\"27055305231CF6F718AD26485499B3ED1CCC8115\",\"name\":\"node-1\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"MVQUuYdJzxmYiJnmffxf40jBXXkwwnkLzt0f4XV+NeQ=\"},\"voting_power\":\"1\"},{\"address\":\"FAD1E8BBC00835B88FAA41B54EAA0D2FCE55FEF0\",\"name\":\"node-2\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"i3QFHggYCqG6ciKmsjAXSt6NKfyUOGjfje5YwYaYOfo=\"},\"voting_power\":\"1\"},{\"address\":\"4F850CA6849EC0B3FC808D912F35CE2DAA222006\",\"name\":\"node-3\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"l+7AqB4df3ckzpF+7Ku4xh9z+WPzhyzjw99WKE0K9oI=\"},\"voting_power\":\"1\"},{\"address\":\"33A24EF38E695529EED806CF70751C2CFC61DEAC\",\"name\":\"node-4\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"bvjpaBraL50Q8rRo+a7HH5HU2YI4lEasxm5CrP/TC6c=\"},\"voting_power\":\"1\"},{\"address\":\"C81783A1C67AD00C82FF093CE36AFF938185E44B\",\"name\":\"node-5\",\"power\":\"1\",\"pub_key\":{\"type\":\"tendermint/PubKeyEd25519\",\"value\":\"QPh4cyJnFKpDwDbU0C30hoQfqwvjCN9xDB8OtomhMkE=\"},\"voting_power\":\"1\"}]}",
  "next_node_id": 7
}
```

You can pause the cluster by `fn dev stop`, and resume it by `fn dev start` at any time; you can also scale up the cluster by `fn dev add-node`, and scale it down by `fn dev del-node`.

At last, if you don't need this cluster anymore, you can permanently destroy it with the `fn dev destroy` subcommand.

The above is the simplest management process of a local development environment, which is enough for developers to self-debug on their localhosts.

But obviously, for example, for the scenario of front-end and back-end joint debugging, the simplest cluster configuration above is not enough, so we need some additional configuration options to meet these requirements. Most of these additional configurations need to be specified during the cluster creation process, that is, specified in the scope of the `fn dev create` subcommand.

Let's check the help information of `fn dev create`:
```
fn-dev-create
Create a new env

USAGE:
    fn dev create [OPTIONS]

FLAGS:
    -h, --help       Prints help information
    -V, --version    Prints version information

OPTIONS:
    -A, --abcid-bin-path <ABCID BIN PATH>              The path of your custom abcid binary
    -E, --abcid-extra-flags <ABCID EXTRA FLAGS>        A pair of quotes should be used when specifying extra flags
    -i, --block-itv-secs <BLOCK INTERVAL>              Block interval in seconds
    -c, --checkpoint-file <CHECKPOINT FILE>            The file path of the checkpoint file
    -e, --env-name <ENV NAME>                          The name of the target env
    -I, --evm-chain-id <EVM CHAIN ID>                  The chain id in the scope of evm logic
    -H, --host-ip <HOST IP>                            The IP of your local host, default to 127.0.0.1
    -T, --tendermint-bin-path <TENDERMINT BIN PATH>    The path of your custom tendermint binary
    -N, --validator-num <VALIDATOR NUMBER>             How many initial validators should be created
```

For the issue of remote joint debugging, we can use the `--host-ip` option to specify the listening address of the target ENV.

A few other commonly used options:
- `-i, --block-itv-secs`, block interval, default to 3s
- `-c, --checkpoint-file`, the path of you custom checkpoint file
- `-I, --evm-chain-id`, the value of this option will be defined as `${EVM_CHAIN_ID}`
- `-N, --validator-num`, 5 initial validators will be created by default, you can change the number by this option
- `-T, --tendermint-bin-path`, use a custom version of the tendermint binary
- `-A, --abcid-bin-path`, use a custom versioln of the abcid binary
- `-E, --abcid-extra-flags`, specify extra flags
  - for example, there is a `--disable-eth-empty-blocks` flag in the `abcid` binary, and it will not be set by `fn dev` by default, you can set it like this `fn dev create -E '--disable-eth-empty-blocks'`

Below is a more complete example with richer options:
```shell
fn dev create \
    -H 192.168.2.5 \
    -e MyEnv \
    -i 1 \
    -N 6 \
    -I 777 \
    -c /tmp/checkpoint.toml \
    -T /tmp/tendermint-v0.33.8 \
    -A /tmp/abcid-v0.4.0-preview \
    -E '--disable-eth-empty-blocks'
```

- all nodes of this ENV will listen on '192.168.2.5'
  - now you can tell the IP address to your frond-end engineers, the joint debugging will be ok
- the name of this ENV is 'MyEnv'
- the block interval will be 1s
- the number of initial validator nodes is 6
- the chain id of evm is 777
- the path of checkpoint file is '/tmp/checkpoint.toml'
- use custom binaries of tendermint and abcid
- `--disable-eth-empty-blocks` is added as an extra flag

The coresponding starting commands of nodes will be(but in one-line style):
```shell
# cat /tmp/__FINDORA_DEV__/envs/MyEnv/3/fn_dev.log

/tmp/tendermint-v0.33.8 node \
    --home /tmp/__FINDORA_DEV__/envs/MyEnv/3 \
    >>/tmp/__FINDORA_DEV__/envs/MyEnv/3/tendermint.log 2>&1 &

EVM_CHAIN_ID=777 FINDORA_BLOCK_ITV=1 \
/tmp/abcid-v0.4.0-preview --enable-query-service --enable-eth-api-service \
    --tendermint-host 192.168.2.5 \
    --tendermint-port 41043 \
    --abcid-port 22480 \
    --submission-service-port 61919 \
    --ledger-service-port 61912 \
    --evm-http-port 21536 \
    --evm-ws-port 34983 \
    --ledger-dir /tmp/__FINDORA_DEV__/envs/MyEnv/3/__findora__ \
    --tendermint-node-key-config-path /tmp/__FINDORA_DEV__/envs/MyEnv/3/config/priv_validator_key.json \
    --disable-eth-empty-blocks \
    --checkpoint-file /tmp/checkpoint.toml \
    >>/tmp/__FINDORA_DEV__/envs/MyEnv/3/app.log 2>&1 &
```

#### Management of multiple clusters

Since each cluster can specify its own executing binaries(tendermint & abcid), the multi-cluster mode is of great significance for functional comparison, testing and problem debugging between different versions or between different features.

Managing multiple clusters, or in other words, managing custom clusters is not much different from the default cluster because resource allocation and process running between different clusters are completely isolated in `fn dev`.

The only difference is that you do not have to explicitly specify the env name when managing the default cluster, but for non-default clusters, all operations must explicitly specify the name of the target env.

For example, for the default cluster, `fn dev stop` is equal to `fn dev stop -e DEFAULT`, both styles are ok; but there is only one style for a custom cluster, that is `fn dev stop -e YourCustomEnv`.

Also, there are some subcommands designed specifically for multi-cluster management:
- `fn dev list`, list the names of all existing ENVs
- `fn dev info-all`, list the details of all existing ENVs
- `fn dev init-all`, initilize all existing ENVs in batch mode
- `fn dev destroy-all`, destroy all existing ENVs

#### Environment variable definitions

Currently no environment variables are defined inside `fn dev`.

#### Internal organization of data and logs

All data and logs are located under `/tmp/__FINDORA_DEV__`, so you should have a big enough `/tmp`.

We can use `tree -F -L 2 /tmp/__FINDORA_DEV__` to check their structures:
```
/tmp/__FINDORA_DEV__/
├── envs/               # existing ENVs
│   ├── DEFAULT/        # the default ENV
│   ├── env_A/          # a custom ENV named 'env_A'
│   └── env_B/          # a custom ENV named 'env_B'
└── ports_cache         # allocated ports
```

Let's check the inner structure of 'DEFAULT', `tree -F -L 1 /tmp/__FINDORA_DEV__/envs/DEFAULT`:
```
/tmp/__FINDORA_DEV__/envs/DEFAULT/
├── 0/           # seed node of this ENV, can *not* be removed dynamicly
├── 1/           # the first validator node of this ENV, can *not* be removed dynamicly
├── 2/           # the second validator node of this ENV, can be removed dynamicly
├── 3/           # the third validator node, similar with the second one
├── 4/           # ...
├── 5/           # ...
└── config.json  # config file of this ENV
```

Then further check the internal structure of a node, `tree -F -L 1 /tmp/__FINDORA_DEV__/envs/DEFAULT/1`:

```
/tmp/__FINDORA_DEV__/envs/DEFAULT/1/
├── config/              # config dir of the tendermint consensus engine
├── data/                # data dir of the tendermint consensus engine
├── tendermint.log       # log of the tendermint consensus engine
├── __findora__/         # data of the 'abcid' process
├── app.log              # log of the 'abcid' process
└── fn_dev.log           # log of the 'fn dev' system
```

Inner management operations of `fn dev` will be logged in the `fn_dev.log` file.

## Compatibility Notes

#### OS compatibility

In theory, it can run well on most Linux and MacOS versions, but it is not suitable for Windows operating systems, and there is currently no compatibility plan for Windows.

#### No breaks to musl compilation

```shell
# host: Linux 5.15.52-gentoo #2 SMP Tue Jul 26 15:14:31 CST 2022 x86_64  GNU/Linux

X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_LIB_DIR=/usr/x86_64-unknown-linux-musl/usr/lib \
X86_64_UNKNOWN_LINUX_MUSL_OPENSSL_INCLUDE_DIR=/usr/x86_64-unknown-linux-musl/usr/include \
\
cargo build --target=x86_64-unknown-linux-musl -p finutils
```