### PR TITLE
Add new field `pubkey_sign_map` for `Transaction` struct

### DIFF
--- a/src/components/finutils/src/common/evm.rs
+++ b/src/components/finutils/src/common/evm.rs
@@ -54,7 +54,7 @@ pub fn transfer_to_account(amount: u64, address: Option<&str>) -> Result<()> {
         .sign(&kp);
 
     let mut tx = builder.take_transaction();
-    tx.sign(&kp);
+    tx.sign_to_map(&kp);
 
     utils::send_tx(&tx)?;
     Ok(())

--- a/src/components/finutils/src/common/mod.rs
+++ b/src/components/finutils/src/common/mod.rs
@@ -85,7 +85,7 @@ pub fn staker_update(cr: Option<&str>, memo: Option<StakerMemo>) -> Result<()> {
         .map(|op| builder.add_operation(op))?;
 
     let mut tx = builder.take_transaction();
-    tx.sign(&kp);
+    tx.sign_to_map(&kp);
 
     utils::send_tx(&tx).c(d!())
 }
@@ -151,7 +151,7 @@ pub fn stake(
     .map(|principal_op| builder.add_operation(principal_op))?;
 
     let mut tx = builder.take_transaction();
-    tx.sign(&kp);
+    tx.sign_to_map(&kp);
 
     utils::send_tx(&tx).c(d!())
 }
@@ -188,8 +188,10 @@ pub fn stake_append(
     )
     .c(d!())
     .map(|principal_op| builder.add_operation(principal_op))?;
+    let mut tx = builder.take_transaction();
+    tx.sign_to_map(&kp);
 
-    utils::send_tx(&builder.take_transaction()).c(d!())
+    utils::send_tx(&tx).c(d!())
 }
 
 /// Withdraw Fra token from findora network for a staker
@@ -237,7 +239,7 @@ pub fn unstake(
     })?;
 
     let mut tx = builder.take_transaction();
-    tx.sign(&kp);
+    tx.sign_to_map(&kp);
 
     utils::send_tx(&tx).c(d!())
 }
@@ -260,7 +262,7 @@ pub fn claim(am: Option<&str>, sk_str: Option<&str>) -> Result<()> {
     })?;
 
     let mut tx = builder.take_transaction();
-    tx.sign(&kp);
+    tx.sign_to_map(&kp);
 
     utils::send_tx(&tx).c(d!())
 }
@@ -663,7 +665,7 @@ fn gen_undelegate_tx(
     }
 
     let mut tx = builder.take_transaction();
-    tx.sign(owner_kp);
+    tx.sign_to_map(owner_kp);
 
     Ok(tx)
 }
@@ -690,7 +692,8 @@ fn gen_delegate_tx(
     })?;
 
     let mut tx = builder.take_transaction();
-    tx.sign(owner_kp);
+
+    tx.sign_to_map(owner_kp);
 
     Ok(tx)
 }
@@ -743,7 +746,7 @@ pub fn create_asset_x(
         .map(|op| builder.add_operation(op))?;
 
     let mut tx = builder.take_transaction();
-    tx.sign(kp);
+    tx.sign_to_map(kp);
 
     utils::send_tx(&tx).map(|_| code)
 }
@@ -785,7 +788,7 @@ pub fn issue_asset_x(
         .map(|op| builder.add_operation(op))?;
 
     let mut tx = builder.take_transaction();
-    tx.sign(kp);
+    tx.sign_to_map(kp);
 
     utils::send_tx(&tx)
 }
@@ -820,7 +823,7 @@ pub fn replace_staker(
 
     builder.add_operation_replace_staker(&keypair, target_pubkey, new_td_addr_pk)?;
     let mut tx = builder.take_transaction();
-    tx.sign(&keypair);
+    tx.sign_to_map(&keypair);
 
     utils::send_tx(&tx).c(d!())?;
     Ok(())

--- a/src/components/finutils/src/common/utils.rs
+++ b/src/components/finutils/src/common/utils.rs
@@ -111,7 +111,7 @@ pub fn transfer_batch(
     builder.add_operation(op);
 
     let mut tx = builder.take_transaction();
-    tx.sign(owner_kp);
+    tx.sign_to_map(owner_kp);
 
     send_tx(&tx).c(d!())
 }

--- a/src/components/finutils/src/txn_builder/mod.rs
+++ b/src/components/finutils/src/txn_builder/mod.rs
@@ -657,7 +657,7 @@ impl TransactionBuilder {
         self
     }
 
-    /// Signing this transaction with XfrKeyPair
+    /// Signing this transaction with XfrKeyPair, but insert `Transaction.signatures`
     pub fn sign(&mut self, kp: &XfrKeyPair) -> &mut Self {
         self.txn.sign(kp);
         self
@@ -672,6 +672,12 @@ impl TransactionBuilder {
         self.txn.check_signature(pk, &sig).c(d!())?;
         self.txn.signatures.push(sig);
         Ok(self)
+    }
+
+    /// Signing this transaction with XfrKeyPair, but insert to `Transaction.pubkey_sign_map`
+    pub fn sign_to_map(&mut self, kp: &XfrKeyPair) -> &mut Self {
+        self.txn.sign_to_map(kp);
+        self
     }
 
     #[allow(missing_docs)]

--- a/src/components/wasm/src/wasm.rs
+++ b/src/components/wasm/src/wasm.rs
@@ -522,7 +522,18 @@ impl TransactionBuilder {
 
     #[allow(missing_docs)]
     pub fn sign(mut self, kp: &XfrKeyPair) -> Result<TransactionBuilder, JsValue> {
+        self.get_builder_mut().sign_to_map(kp);
+
+        Ok(self)
+    }
+
+    #[allow(missing_docs)]
+    pub fn sign_origin(
+        mut self,
+        kp: &XfrKeyPair,
+    ) -> Result<TransactionBuilder, JsValue> {
         self.get_builder_mut().sign(kp);
+
         Ok(self)
     }
 

--- a/src/ledger/src/data_model/mod.rs
+++ b/src/ledger/src/data_model/mod.rs
@@ -1826,22 +1826,14 @@ impl Transaction {
     #[inline(always)]
     #[allow(missing_docs)]
     pub fn check_has_signature_from_map(&self, public_key: &XfrPublicKey) -> Result<()> {
-        let serialized = Serialized::new(&self.body);
-
-        let mut r = Ok(());
-
         if let Some(sign) = self.pubkey_sign_map.get(public_key) {
-            if sign.0.verify(public_key, &serialized).is_err() {
-                r = Err(eg!());
-            }
+            sign.0.verify(public_key, &Serialized::new(&self.body))
         } else {
-            r = Err(eg!(
+            Err(eg!(
                 "the pubkey not match: {}",
                 public_key_to_base64(public_key)
-            ));
+            ))
         }
-
-        r
     }
 
     /// NOTE: This method is used to verify the signature in the transaction,

--- a/src/ledger/src/data_model/mod.rs
+++ b/src/ledger/src/data_model/mod.rs
@@ -11,16 +11,15 @@ mod test;
 
 pub use effects::{BlockEffect, TxnEffect};
 
-use crate::staking::ops::replace_staker::ReplaceStakerOps;
-
 use {
     crate::converter::ConvertAccount,
     crate::staking::{
         ops::{
             claim::ClaimOps, delegation::DelegationOps,
             fra_distribution::FraDistributionOps, governance::GovernanceOps,
-            mint_fra::MintFraOps, undelegation::UnDelegationOps,
-            update_staker::UpdateStakerOps, update_validator::UpdateValidatorOps,
+            mint_fra::MintFraOps, replace_staker::ReplaceStakerOps,
+            undelegation::UnDelegationOps, update_staker::UpdateStakerOps,
+            update_validator::UpdateValidatorOps,
         },
         Staking,
     },
@@ -28,6 +27,7 @@ use {
     bitmap::SparseMap,
     cryptohash::{sha256::Digest as BitDigest, HashValue},
     fbnc::NumKey,
+    globutils::wallet::public_key_to_base64,
     globutils::{HashOf, ProofOf, Serialized, SignatureOf},
     lazy_static::lazy_static,
     rand::Rng,
@@ -1314,6 +1314,9 @@ pub struct Transaction {
     #[serde(default)]
     #[serde(skip_serializing_if = "is_default")]
     pub signatures: Vec<SignatureOf<TransactionBody>>,
+    #[serde(default)]
+    #[serde(skip_serializing_if = "is_default")]
+    pub pubkey_sign_map: HashMap<XfrPublicKey, SignatureOf<TransactionBody>>,
 }
 
 #[allow(missing_docs)]
@@ -1702,6 +1705,7 @@ impl Transaction {
         Transaction {
             body: TransactionBody::from_token(no_replay_token),
             signatures: Vec::new(),
+            pubkey_sign_map: Default::default(),
         }
     }
 
@@ -1722,6 +1726,7 @@ impl Transaction {
                 seq_id,
             )),
             signatures: Vec::new(),
+            pubkey_sign_map: Default::default(),
         };
         tx.add_operation(op);
         tx
@@ -1738,6 +1743,13 @@ impl Transaction {
     #[allow(missing_docs)]
     pub fn sign(&mut self, keypair: &XfrKeyPair) {
         self.signatures.push(SignatureOf::new(keypair, &self.body));
+    }
+
+    #[inline(always)]
+    #[allow(missing_docs)]
+    pub fn sign_to_map(&mut self, keypair: &XfrKeyPair) {
+        self.pubkey_sign_map
+            .insert(keypair.pub_key, SignatureOf::new(keypair, &self.body));
     }
 
     #[inline(always)]
@@ -1811,50 +1823,79 @@ impl Transaction {
         Err(eg!())
     }
 
+    #[inline(always)]
+    #[allow(missing_docs)]
+    pub fn check_has_signature_from_map(&self, public_key: &XfrPublicKey) -> Result<()> {
+        let serialized = Serialized::new(&self.body);
+
+        let mut r = Ok(());
+
+        if let Some(sign) = self.pubkey_sign_map.get(public_key) {
+            if sign.0.verify(public_key, &serialized).is_err() {
+                r = Err(eg!());
+            }
+        } else {
+            r = Err(eg!(
+                "the pubkey not match: {}",
+                public_key_to_base64(public_key)
+            ));
+        }
+
+        r
+    }
+
     /// NOTE: This method is used to verify the signature in the transaction,
     /// when the user constructs the transaction not only needs to sign each `operation`,
     /// but also needs to sign the whole transaction, otherwise it will not be passed here
     #[inline(always)]
     pub fn check_tx(&self) -> Result<()> {
+        let select_check = |tx: &Transaction, pk: &XfrPublicKey| -> Result<()> {
+            if tx.signatures.is_empty() {
+                tx.check_has_signature_from_map(pk)
+            } else {
+                tx.check_has_signature(pk)
+            }
+        };
+
         for operation in self.body.operations.iter() {
             match operation {
                 Operation::TransferAsset(o) => {
                     for pk in o.get_owner_addresses().iter() {
-                        self.check_has_signature(pk).c(d!())?;
+                        select_check(self, pk).c(d!())?;
                     }
                 }
                 Operation::IssueAsset(o) => {
-                    self.check_has_signature(&o.pubkey.key).c(d!())?;
+                    select_check(self, &o.pubkey.key).c(d!())?;
                 }
                 Operation::DefineAsset(o) => {
-                    self.check_has_signature(&o.pubkey.key).c(d!())?;
+                    select_check(self, &o.pubkey.key).c(d!())?;
                 }
                 Operation::UpdateMemo(o) => {
-                    self.check_has_signature(&o.pubkey).c(d!())?;
+                    select_check(self, &o.pubkey).c(d!())?;
                 }
                 Operation::UpdateStaker(o) => {
-                    self.check_has_signature(&o.pubkey).c(d!())?;
+                    select_check(self, &o.pubkey).c(d!())?;
                 }
                 Operation::Delegation(o) => {
-                    self.check_has_signature(&o.pubkey).c(d!())?;
+                    select_check(self, &o.pubkey).c(d!())?;
                 }
                 Operation::UnDelegation(o) => {
-                    self.check_has_signature(&o.pubkey).c(d!())?;
+                    select_check(self, &o.pubkey).c(d!())?;
                 }
                 Operation::Claim(o) => {
-                    self.check_has_signature(&o.pubkey).c(d!())?;
+                    select_check(self, &o.pubkey).c(d!())?;
                 }
                 Operation::UpdateValidator(_) => {}
                 Operation::Governance(_) => {}
                 Operation::FraDistribution(_) => {}
                 Operation::MintFra(_) => {}
                 Operation::ConvertAccount(o) => {
-                    self.check_has_signature(&o.signer).c(d!())?;
+                    select_check(self, &o.signer).c(d!())?;
                 }
                 Operation::ReplaceStaker(o) => {
                     if !o.get_related_pubkeys().is_empty() {
-                        for get_related_pubkey in o.get_related_pubkeys() {
-                            self.check_has_signature(&get_related_pubkey).c(d!())?;
+                        for pk in o.get_related_pubkeys() {
+                            select_check(self, &pk).c(d!())?;
                         }
                     }
                 }

--- a/src/ledger/src/store/utils.rs
+++ b/src/ledger/src/store/utils.rs
@@ -90,8 +90,7 @@ pub fn fra_gen_initial_tx(fra_owner_kp: &XfrKeyPair) -> Transaction {
 
     tx.add_operation(Operation::IssueAsset(asset_issuance_operation));
 
-    tx.sign(fra_owner_kp);
-    tx.sign(fra_owner_kp);
+    tx.sign_to_map(fra_owner_kp);
 
     tx
 }


### PR DESCRIPTION
New field `pubkey_sign_map` in the `Transaction` struct, and `check_tx` method is compatible with the previous data format

