### PR TITLE
Upgrade libsecp256k1 version

### DIFF
--- a/src/components/contracts/primitives/mocks/Cargo.toml
+++ b/src/components/contracts/primitives/mocks/Cargo.toml
@@ -12,7 +12,7 @@ abci = { git = "https://github.com/FindoraNetwork/tendermint-abci", tag = "0.7.4
 baseapp = { path = "../../baseapp" }
 ethereum = { version = "0.12.0", default-features = false, features = ["with-serde"] }
 lazy_static = "1.4.0"
-libsecp256k1 = { version = "0.5", features = ["static-context", "hmac"] }
+libsecp256k1 = { version = "0.7", features = ["static-context", "hmac"] }
 primitive-types = { version = "0.11.1", default-features = false, features = ["rlp", "byteorder", "serde"] }
 rand_chacha = "0.3"
 rlp = "0.5"

--- a/src/components/contracts/primitives/types/Cargo.toml
+++ b/src/components/contracts/primitives/types/Cargo.toml
@@ -14,7 +14,7 @@ ethereum = { version = "0.12.0", default-features = false, features = ["with-ser
 fixed-hash = "0.7.0"
 hex = "0.4.2"
 globutils = { path = "../../../../libs/globutils" }
-libsecp256k1 = { version = "0.5", features = ["static-context", "hmac"] }
+libsecp256k1 = { version = "0.7", features = ["static-context", "hmac"] }
 primitive-types = { version = "0.11.1", default-features = false, features = ["rlp", "byteorder", "serde"] }
 ruc = "1.0"
 serde = { version = "1.0.124", features = ["derive"] }

--- a/src/components/contracts/primitives/utils/Cargo.toml
+++ b/src/components/contracts/primitives/utils/Cargo.toml
@@ -15,7 +15,7 @@ bip0039 = "0.8.0"
 blake2-rfc = "0.2.18"
 byteorder = "1.4.3"
 hex = "0.4.2"
-libsecp256k1 = { version = "0.5", features = ["static-context", "hmac"] }
+libsecp256k1 = { version = "0.7", features = ["static-context", "hmac"] }
 primitive-types = { version = "0.11.1", default-features = false, features = ["rlp", "byteorder", "serde"] }
 protobuf = "2.16"
 rand = "0.8"

--- a/src/components/contracts/rpc/Cargo.toml
+++ b/src/components/contracts/rpc/Cargo.toml
@@ -25,7 +25,7 @@ jsonrpc-derive = "18.0"
 jsonrpc-pubsub = "18.0"
 jsonrpc-http-server = "18.0"
 jsonrpc-tcp-server = "18.0"
-libsecp256k1 = { version = "0.5", features = ["static-context", "hmac"] }
+libsecp256k1 = { version = "0.7", features = ["static-context", "hmac"] }
 lazy_static = "1.4.0"
 log = "0.4.8"
 parking_lot = "0.12"


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [ ] make fmt
  - [ ] make lint
  - [ ] make test

* **The major changes of this PR**


* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

Checked: https://github.com/paritytech/libsecp256k1/blob/master/CHANGELOG.md
And reviewed 0.5 ~ 0.7.1 commits, This is a safe upgrade

