### PR TITLE
update storage to speedup catch-up

### DIFF
--- a/src/components/contracts/baseapp/Cargo.toml
+++ b/src/components/contracts/baseapp/Cargo.toml
@@ -22,8 +22,8 @@ protobuf = "2.16"
 ruc = "1.0"
 serde = {version = "1.0.124", features = ["derive"]}
 serde_json = "1.0.40"
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
 
 # primitives
 fp-core = {path = "../primitives/core"}

--- a/src/components/contracts/modules/account/Cargo.toml
+++ b/src/components/contracts/modules/account/Cargo.toml
@@ -15,7 +15,7 @@ primitive-types = { version = "0.11.1", default-features = false, features = ["r
 ruc = "1.0"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0.64"
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
 
 # primitives, don't depend on any modules
 fp-core = { path = "../../primitives/core" }
@@ -27,4 +27,4 @@ fp-types = { path = "../../primitives/types" }
 rand_chacha = "0.2"
 parking_lot = "0.12"
 zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }

--- a/src/components/contracts/modules/ethereum/Cargo.toml
+++ b/src/components/contracts/modules/ethereum/Cargo.toml
@@ -35,8 +35,8 @@ config = { path = "../../../config"}
 baseapp = { path = "../../baseapp" }
 fp-mocks = { path = "../../primitives/mocks" }
 module-account = { path = "../account" }
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
 
 [features]
 default = []

--- a/src/components/contracts/modules/evm/Cargo.toml
+++ b/src/components/contracts/modules/evm/Cargo.toml
@@ -32,8 +32,8 @@ fp-traits = { path = "../../primitives/traits" }
 fp-types = { path = "../../primitives/types" }
 fp-utils = { path = "../../primitives/utils" }
 config = { path = "../../../config"}
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
 
 [dev-dependencies]
 baseapp = { path = "../../baseapp" }

--- a/src/components/contracts/modules/evm/precompile/Cargo.toml
+++ b/src/components/contracts/modules/evm/precompile/Cargo.toml
@@ -15,8 +15,6 @@ evm-precompile-basic = {path = "./basic"}
 evm-precompile-frc20 = {path = "./frc20"}
 evm-precompile-modexp = {path = "./modexp"}
 evm-precompile-sha3fips = {path = "./sha3fips"}
-fin_db = {git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1"}
 fp-core = {path = "../../../primitives/core"}
 module-evm = {path = "../../../modules/evm"}
 parking_lot = "0.12"
-storage = {git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.1"}

--- a/src/components/contracts/primitives/core/Cargo.toml
+++ b/src/components/contracts/primitives/core/Cargo.toml
@@ -16,8 +16,8 @@ parking_lot = "0.12"
 primitive-types = { version = "0.11.1", default-features = false, features = ["rlp", "byteorder", "serde"] }
 ruc = "1.0"
 serde = { version = "1.0.124", features = ["derive"] }
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2", optional = true }
-fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2", optional = true }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0", optional = true }
+fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0", optional = true }
 serde_with = { version = "1.9.4"}
 
 # primitives

--- a/src/components/contracts/primitives/storage/Cargo.toml
+++ b/src/components/contracts/primitives/storage/Cargo.toml
@@ -15,10 +15,10 @@ ruc = "1.0"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0"
 sha2 = "0.9.5"
-storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
 
 # primitives
 fp-core = { path = "../core" }
 
 [dev-dependencies]
-temp_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
+temp_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**
1. update storage version to v1.0.0 to make commit faster on history(auxiliary) data. 

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

