### PR TITLE
fix update validators

### DIFF
--- a/src/components/config/src/abci/mod.rs
+++ b/src/components/config/src/abci/mod.rs
@@ -58,7 +58,7 @@ impl CheckPointConfig {
                                 apy_v7_upgrade_height: 0,
                                 ff_addr_extra_fix_height: 0,
                                 nonconfidential_balance_fix_height: 0,
-                                unbond_block_cnt: 5,
+                                unbond_block_cnt: 3600 * 24 * 21 / 16,
                                 fix_unpaid_delegation_height: 0,
                                 fix_undelegation_missing_reward_height: 0,
                                 evm_checktx_nonce: 0,

--- a/src/components/config/src/abci/mod.rs
+++ b/src/components/config/src/abci/mod.rs
@@ -33,6 +33,7 @@ pub struct CheckPointConfig {
     pub utxo_checktx_height: i64,
     pub fix_delegators_am_height: u64,
     pub validators_limit_v2_height: u64,
+    pub fix_update_validators_height: i64,
 }
 
 impl CheckPointConfig {
@@ -57,13 +58,14 @@ impl CheckPointConfig {
                                 apy_v7_upgrade_height: 0,
                                 ff_addr_extra_fix_height: 0,
                                 nonconfidential_balance_fix_height: 0,
-                                unbond_block_cnt: 3600 * 24 * 21 / 16,
+                                unbond_block_cnt: 5,
                                 fix_unpaid_delegation_height: 0,
                                 fix_undelegation_missing_reward_height: 0,
                                 evm_checktx_nonce: 0,
                                 utxo_checktx_height: 0,
                                 fix_delegators_am_height: 0,
                                 validators_limit_v2_height: 0,
+                                fix_update_validators_height: 0,
                             };
                             #[cfg(not(feature = "debug_env"))]
                             let config = CheckPointConfig {
@@ -85,6 +87,7 @@ impl CheckPointConfig {
                                 utxo_checktx_height: 30000000,
                                 fix_delegators_am_height: 30000000,
                                 validators_limit_v2_height: 30000000,
+                                fix_update_validators_height: 30000000,
                             };
                             let content = toml::to_string(&config).unwrap();
                             file.write_all(content.as_bytes()).unwrap();


### PR DESCRIPTION
set `VALIDATOR_LIMIT` and `VALIDATOR_LIMIT_V2` both all 3
set `fix_update_validators_height = 20` in checkpoint.toml 
local test and result picture

this origin logic result
![16](https://user-images.githubusercontent.com/31642966/191034382-3b846b41-867a-4dac-9cc8-bd95e3fc063f.png)

fix after logic result
![17](https://user-images.githubusercontent.com/31642966/191034502-bfdd1b0a-be1e-4498-801f-48f451560a0e.png)

when the height is equal to 20, it can be seen that abci sent the power of the two validators to td for 0, and the other unchanged was not submitted
![image](https://user-images.githubusercontent.com/31642966/191034649-90cefd81-cc90-40d9-a6d3-5db669022908.png)

results of the historical data compatibility test will be added later
