### PR TITLE
Rollback wasm bindgen

### DIFF
--- a/src/components/wasm/Cargo.toml
+++ b/src/components/wasm/Cargo.toml
@@ -24,7 +24,7 @@ rand_chacha = "0.3"
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0"
-wasm-bindgen = { version = "0.2.62", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"] }
 bs58 = "0.4"
 
 ring = "0.16.19"
@@ -71,7 +71,7 @@ features = [
 serde = "1.0.124"
 serde_json = "1.0.41"
 vergen = "=3.1.0"
-wasm-bindgen = { version = "0.2.62", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"] }
 
 [dev-dependencies]
 # Must enable the "js"-feature,


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [] make fmt
  - [] make lint
  - [ ] make test

* **The major changes of this PR**

latest wasm-bindgen is incompatible, because of BigInt, now rollback to 0.2.73

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

