### PR TITLE
Tracking issue for restoring the main branch

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -2,6 +2,14 @@ version: 2
 updates:
   - package-ecosystem: "cargo"
     directory: "/"
+    target-branch: "develop"
     open-pull-requests-limit: 20
     schedule:
       interval: "daily"
+
+  - package-ecosystem: "cargo"
+    directory: "/"
+    schedule:
+      interval: "daily"
+    # security update only
+    open-pull-requests-limit: 0

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -52,3 +52,9 @@ overflow-checks = false
 [profile.dev.package.curve25519-dalek]
 opt-level = 1
 overflow-checks = false
+
+[patch.crates-io]
+ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", rev = "ad461f" }
+curve25519-dalek = { git = "https://github.com/FindoraNetwork/curve25519-dalek", rev = "076cf3" }
+x25519-dalek = { git = "https://github.com/FindoraNetwork/x25519-dalek", rev = "ea047a" }
+

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -55,6 +55,5 @@ overflow-checks = false
 
 [patch.crates-io]
 ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", rev = "ad461f" }
-curve25519-dalek = { git = "https://github.com/FindoraNetwork/curve25519-dalek", rev = "076cf3" }
-x25519-dalek = { git = "https://github.com/FindoraNetwork/x25519-dalek", rev = "ea047a" }
-
+curve25519-dalek = { git = "https://github.com/FindoraNetwork/curve25519-dalek", rev = "a2df65" }
+x25519-dalek = { git = "https://github.com/FindoraNetwork/x25519-dalek", rev = "53bb1a" }

--- a/src/components/abciapp/Cargo.toml
+++ b/src/components/abciapp/Cargo.toml
@@ -41,7 +41,7 @@ percent-encoding = "2.1.0"
 
 nix = "0.22.1"
 
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
+zei = { git = "https://github.com/FindoraNetwork/zei", branch = "stable-main" }
 ruc = { version = "1.0.5", default-features = false, features = ["compact"] }
 abci = { git = "https://github.com/FindoraNetwork/tendermint-abci", tag = "0.7.4" }
 config = { path = "../config"}

--- a/src/components/contracts/modules/account/Cargo.toml
+++ b/src/components/contracts/modules/account/Cargo.toml
@@ -26,5 +26,5 @@ fp-types = { path = "../../primitives/types" }
 [dev-dependencies]
 rand_chacha = "0.2"
 parking_lot = "0.12"
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
+zei = { git = "https://github.com/FindoraNetwork/zei", branch = "stable-main" }
 fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }

--- a/src/components/contracts/primitives/mocks/Cargo.toml
+++ b/src/components/contracts/primitives/mocks/Cargo.toml
@@ -18,7 +18,7 @@ rand_chacha = "0.2"
 rlp = "0.5"
 serde_json = "1.0"
 sha3 = "0.8"
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
+zei = { git = "https://github.com/FindoraNetwork/zei", branch = "stable-main" }
 
 # primitives
 fp-traits = { path = "../traits" }

--- a/src/components/contracts/primitives/types/Cargo.toml
+++ b/src/components/contracts/primitives/types/Cargo.toml
@@ -19,7 +19,7 @@ ruc = "1.0"
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0"
 sha3 = "0.8"
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
+zei = { git = "https://github.com/FindoraNetwork/zei", branch = "stable-main" }
 fixed-hash = "0.7.0"
 
 # primitives

--- a/src/components/finutils/Cargo.toml
+++ b/src/components/finutils/Cargo.toml
@@ -21,7 +21,7 @@ rand_chacha = "0.2"
 curve25519-dalek = { version = "3.0", features = ["serde"] }
 wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"] }
 
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
+zei = { git = "https://github.com/FindoraNetwork/zei", branch = "stable-main" }
 ruc = "1.0"
 nix = "0.25"
 toml_edit = "0.14"

--- a/src/components/wasm/Cargo.toml
+++ b/src/components/wasm/Cargo.toml
@@ -32,7 +32,7 @@ bech32 = "0.7.2"
 # OR the compiling will fail.
 getrandom = { version = "0.2", features = ["js"] }
 
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
+zei = { git = "https://github.com/FindoraNetwork/zei", branch = "stable-main" }
 ruc = "1.0"
 
 finutils = { path = "../finutils", default-features = false }

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -30,9 +30,9 @@ config = { path = "../components/config" }
 fp-types = { path = "../components/contracts/primitives/types" }
 
 ruc = "1.0"
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
-zeiutils = { package = "utils", git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
-bulletproofs = { package = "bulletproofs", git = "https://github.com/FindoraNetwork/bp", branch = "batch_verification", features = ["yoloproofs"] }
+zei = { git = "https://github.com/FindoraNetwork/zei", branch = "stable-main" }
+zeiutils = { package = "utils", git = "https://github.com/FindoraNetwork/zei", branch = "stable-main" }
+bulletproofs = { package = "bulletproofs", git = "https://github.com/FindoraNetwork/bp", rev = "57633a", features = ["yoloproofs"] }
 fbnc = { version = "0.2.9", default-features = false}
 
 num-bigint = "0.4.3"

--- a/src/libs/credentials/Cargo.toml
+++ b/src/libs/credentials/Cargo.toml
@@ -12,4 +12,4 @@ linear-map = {version = "1.2.0", features = ["serde_impl"] }
 serde = "1.0.124"
 serde_derive = "1.0"
 wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"]  }
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
+zei = { git = "https://github.com/FindoraNetwork/zei", branch = "stable-main" }

--- a/src/libs/globutils/Cargo.toml
+++ b/src/libs/globutils/Cargo.toml
@@ -12,7 +12,7 @@ serde_json = "1.0"
 time = "0.3"
 rand = "0.8"
 cryptohash = { path = "../cryptohash" }
-zei = { git = "https://github.com/FindoraNetwork/zei", tag = "v0.1.4x" }
+zei = { git = "https://github.com/FindoraNetwork/zei", branch = "stable-main" }
 hex = "0.4.2"
 
 base64 = "0.12"


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [ ] make fmt
  - [ ] make lint
  - [ ] make test

* **The major changes of this PR**

It appears that dependabot has caused the main branch to have some incompatibility issues not shown up before. 

The `stable-main` restores the main branch. Before merging, we need to force push the main before the last chunk of the dependabot update.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

