### PR TITLE
Upgrade actions/checkout and actions/cache in GitHub CI

### DIFF
--- a/.github/workflows/Develop.yml
+++ b/.github/workflows/Develop.yml
@@ -16,7 +16,7 @@ jobs:
       PRIVATE_ECR_URL: 358484141435.dkr.ecr.us-west-2.amazonaws.com
       PUBLIC_ECR_URL: public.ecr.aws/k6m5b6e2
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/DevelopArm.yml
+++ b/.github/workflows/DevelopArm.yml
@@ -19,7 +19,7 @@ jobs:
       PRIVATE_ECR_URL: 358484141435.dkr.ecr.us-west-2.amazonaws.com
       PUBLIC_ECR_URL: public.ecr.aws/k6m5b6e2
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/Features.yml
+++ b/.github/workflows/Features.yml
@@ -15,7 +15,7 @@ jobs:
         platform: [scalable]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/Fn.yml
+++ b/.github/workflows/Fn.yml
@@ -14,7 +14,7 @@ jobs:
         platform: [scalable]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/Main.yml
+++ b/.github/workflows/Main.yml
@@ -16,7 +16,7 @@ jobs:
       PRIVATE_ECR_URL: 358484141435.dkr.ecr.us-west-2.amazonaws.com
       PUBLIC_ECR_URL: public.ecr.aws/k6m5b6e2
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/Others.yml
+++ b/.github/workflows/Others.yml
@@ -12,7 +12,7 @@ jobs:
         platform: [scalable]
     runs-on: ${{ matrix.platform }}
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: nightly-2021-03-24

--- a/.github/workflows/Release.yml
+++ b/.github/workflows/Release.yml
@@ -17,7 +17,7 @@ jobs:
       PUBLIC_ECR_URL: public.ecr.aws/k6m5b6e2
       DOCKERHUB_URL: findoranetwork
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/ReleaseArm.yml
+++ b/.github/workflows/ReleaseArm.yml
@@ -17,7 +17,7 @@ jobs:
       PUBLIC_ECR_URL: public.ecr.aws/k6m5b6e2
       DOCKERHUB_URL: findoranetwork
     steps:
-    - uses: actions/checkout@v2
+    - uses: actions/checkout@v3
     - uses: actions-rs/toolchain@v1
       with:
         toolchain: stable

--- a/.github/workflows/WasmCat.yml
+++ b/.github/workflows/WasmCat.yml
@@ -15,7 +15,7 @@ jobs:
     if: github.event_name != 'pull_request' && github.event.pull_request.number == ''
     steps:
       - name: Checkout platform branch
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
 
       - name: Extract vars
         id: vars
@@ -37,7 +37,7 @@ jobs:
         run: curl https://rustwasm.github.io/wasm-pack/installer/init.sh -sSf | sh
 
       - name: Using cache to speed up
-        uses: actions/cache@v2
+        uses: actions/cache@v3
         with:
           path: |
             ~/.cargo/bin/

--- a/.github/workflows/WasmCatDelete.yml
+++ b/.github/workflows/WasmCatDelete.yml
@@ -6,7 +6,7 @@ on: delete
 jobs:
   delete:
     runs-on: ubuntu-latest
-    # check again this is a delete branch event 
+    # check again this is a delete-branch event
     if: github.event.ref_type == 'branch'
     steps:
       - name: Delete wasm-js-bindings branch


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [ ] make fmt
  - [ ] make lint
  - [ ] make test

* **The major changes of this PR**

This PR performs some upgrades to the actions modules. This is necessary since GitHub Actions appear to want to disable some deprecated features.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

