### PR TITLE
Use a tagged version of Noah

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,11 +66,11 @@ ark-ed-on-bls12-381 = { git = "https://github.com/FindoraNetwork/ark-curves" }
 ark-algebra-test-templates = { git = "https://github.com/FindoraNetwork/ark-algebra" }
 curve25519-dalek = { git = "https://github.com/FindoraNetwork/curve25519-dalek", tag = "v3.2.0-f" }
 ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", tag = "v1.0.1-f" }
-bulletproofs = { git = "https://github.com/FindoraNetwork/bp" }
+bulletproofs = { git = "https://github.com/FindoraNetwork/bp", tag = "v1.0.1-f" }
 
-noah = { git = "https://github.com/FindoraNetwork/noah" }
-noah-accumulators = { git = "https://github.com/FindoraNetwork/noah" }
-noah-algebra = { git = "https://github.com/FindoraNetwork/noah" }
-noah-crypto = { git = "https://github.com/FindoraNetwork/noah" }
-noah-plonk = { git = "https://github.com/FindoraNetwork/noah" }
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-accumulators = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-crypto = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-plonk = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 

--- a/src/components/abciapp/Cargo.toml
+++ b/src/components/abciapp/Cargo.toml
@@ -44,8 +44,8 @@ ruc = { version = "1.0.5", default-features = false, features = ["compact"] }
 module-evm = { path = "../contracts/modules/evm"}
 ethereum-types = { version = "0.13.1", default-features = false }
 
-noah = "0.2"
-noah-algebra = "0.2"
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 
 abci = { git = "https://github.com/FindoraNetwork/tendermint-abci", tag = "0.7.4" }
 config = { path = "../config"}

--- a/src/components/contracts/modules/account/Cargo.toml
+++ b/src/components/contracts/modules/account/Cargo.toml
@@ -30,4 +30,4 @@ parking_lot = "0.12"
 rand_chacha = "0.3"
 storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
 fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
-noah = "0.2"
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }

--- a/src/components/contracts/modules/evm/Cargo.toml
+++ b/src/components/contracts/modules/evm/Cargo.toml
@@ -24,8 +24,8 @@ serde_json = "1.0.64"
 sha3 = { version = "0.10", default-features = false }
 hex = "0.4.2"
 ethabi = "17.1.0"
-noah = "0.2"
-noah-algebra = "0.2"
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 
 # primitives, don't depend on any modules
 fp-core = { path = "../../primitives/core" }

--- a/src/components/contracts/primitives/mocks/Cargo.toml
+++ b/src/components/contracts/primitives/mocks/Cargo.toml
@@ -18,7 +18,7 @@ rand_chacha = "0.3"
 rlp = "0.5"
 serde_json = "1.0"
 sha3 = "0.10"
-noah = "0.2"
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 
 # primitives
 fp-traits = { path = "../traits" }

--- a/src/components/contracts/primitives/types/Cargo.toml
+++ b/src/components/contracts/primitives/types/Cargo.toml
@@ -21,8 +21,8 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0"
 serde-big-array = "0.4"
 sha3 = "0.10"
-noah = "0.2"
-noah-algebra = "0.2"
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 
 # primitives
 fp-utils = { path = "../utils" }

--- a/src/components/finutils/Cargo.toml
+++ b/src/components/finutils/Cargo.toml
@@ -9,7 +9,7 @@ edition = "2021"
 attohttpc = { version = "0.18", default-features = false, features = ["compress", "json", "tls-rustls"] }
 base64 = "0.13"
 clap = { version = "2.33.3", features = ["yaml"] }
-curve25519-dalek = { version = "3.0", features = ["serde"] }
+curve25519-dalek = { git = "https://github.com/FindoraNetwork/curve25519-dalek", tag = "v3.2.0-f" }
 digest = '0.10'
 hex = "0.4.2"
 lazy_static = "1.4.0"
@@ -26,9 +26,9 @@ tokio = "1.10.1"
 wasm-bindgen = { version = "0.2.50", features = ["serde-serialize"] }
 getrandom = "0.2"
 
-noah = "0.2"
-noah-crypto = "0.2"
-noah-algebra = "0.2"
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-crypto = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 nix = "0.25"
 toml_edit = "0.15"
 

--- a/src/components/wallet_mobile/Cargo.toml
+++ b/src/components/wallet_mobile/Cargo.toml
@@ -32,8 +32,8 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_derive = "^1.0.59"
 serde_json = "1.0"
 
-noah = "0.2"
-noah-algebra = "0.2"
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 
 finutils = { path = "../finutils", default-features = false, features = []}
 fp-types = { path = "../contracts/primitives/types" }

--- a/src/components/wasm/Cargo.toml
+++ b/src/components/wasm/Cargo.toml
@@ -36,9 +36,9 @@ ruc = "1.0"
 # OR the compiling will fail.
 getrandom = { version = "0.2", features = ["js"] }
 
-noah = "0.2"
-noah-algebra = "0.2"
-noah-crypto = "0.2"
+noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-crypto  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 
 finutils = { path = "../finutils", default-features = false }
 globutils = { path = "../../libs/globutils" }

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -10,9 +10,9 @@ base64 = "0.13"
 bs58 = "0.4"
 bincode = "1.3.1"
 byteorder = "1.0.0"
-curve25519-dalek = { version = "3.0", features = ["serde"] }
+curve25519-dalek = { git = "https://github.com/FindoraNetwork/curve25519-dalek", tag = "v3.2.0-f" }
 digest = '0.10'
-ed25519-dalek = "1.0.0"
+ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", tag = "v1.0.1-f" }
 hex = "0.4.2"
 lazy_static = { version = "1.2.0" }
 log="*"
@@ -34,10 +34,10 @@ fp-utils = { path = "../components/contracts/primitives/utils" }
 itertools = "0.10"
 ruc = "1.0"
 
-noah = "0.2"
-noah-crypto = "0.2"
-noah-algebra = "0.2"
-bulletproofs = "2.0"
+noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-crypto  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+bulletproofs = { git = "https://github.com/FindoraNetwork/bp", tag = "v1.0.1-f" }
 
 fbnc = { version = "0.2.9", default-features = false}
 
@@ -71,7 +71,7 @@ fs2 = "0.4"
 storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2", optional = true }
 fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2", optional = true }
 sparse_merkle_tree = { path = "../libs/sparse_merkle_tree" }
-noah-accumulators = "0.2"
+noah-accumulators = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 parking_lot = { version = "0.11", features = ["wasm-bindgen"] }

--- a/src/libs/credentials/Cargo.toml
+++ b/src/libs/credentials/Cargo.toml
@@ -12,4 +12,4 @@ linear-map = {version = "1.2.0", features = ["serde_impl"] }
 serde = "1.0.124"
 serde_derive = "1.0"
 wasm-bindgen = { version = "0.2.50", features = ["serde-serialize"]  }
-noah = "0.2"
+noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }

--- a/src/libs/globutils/Cargo.toml
+++ b/src/libs/globutils/Cargo.toml
@@ -12,9 +12,9 @@ serde_json = "1.0"
 time = "0.3"
 rand = "0.8"
 cryptohash = { path = "../cryptohash" }
-noah = "0.2"
-noah-crypto = "0.2"
-noah-algebra = "0.2"
+noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-crypto  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 hex = "0.4.2"
 bip32 = "0.3.0"
 

--- a/src/libs/sparse_merkle_tree/Cargo.toml
+++ b/src/libs/sparse_merkle_tree/Cargo.toml
@@ -25,7 +25,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.10"
 storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
-noah = "0.2"
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
 
 [dev-dependencies]
 temp_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [ ] make fmt
  - [ ] make lint
  - [ ] make test

* **The major changes of this PR**

Previously the platform is pointing to the latest version of Noah. This should no longer work as we are changing the dependency at this moment. This PR fixes so.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

