### PR TITLE
Use noah v0.3.0 to make sure all crypto dependencies are tagged

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -66,11 +66,3 @@ ark-ed-on-bls12-381 = { git = "https://github.com/FindoraNetwork/ark-curves", ta
 ark-algebra-test-templates = { git = "https://github.com/FindoraNetwork/ark-algebra", tag = "stable-2022" }
 curve25519-dalek = { git = "https://github.com/FindoraNetwork/curve25519-dalek", tag = "v3.2.0-f" }
 ed25519-dalek = { git = "https://github.com/FindoraNetwork/ed25519-dalek", tag = "v1.0.1-f" }
-bulletproofs = { git = "https://github.com/FindoraNetwork/bp", tag = "v1.0.1-f" }
-
-noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-accumulators = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-crypto = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-plonk = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-

--- a/src/components/abciapp/Cargo.toml
+++ b/src/components/abciapp/Cargo.toml
@@ -44,8 +44,8 @@ ruc = { version = "1.0.5", default-features = false, features = ["compact"] }
 module-evm = { path = "../contracts/modules/evm"}
 ethereum-types = { version = "0.13.1", default-features = false }
 
-noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 
 abci = { git = "https://github.com/FindoraNetwork/tendermint-abci", tag = "0.7.4" }
 config = { path = "../config"}

--- a/src/components/abciapp/src/abci/server/callback/mod.rs
+++ b/src/components/abciapp/src/abci/server/callback/mod.rs
@@ -378,8 +378,8 @@ pub fn deliver_tx(
                     let mut la = s.la.write();
                     let mut laa = la.get_committed_state().write();
                     if let Some(tx) = staking::system_prism_mint_pay(
-                        &mut *laa,
-                        &mut *s.account_base_app.write(),
+                        &mut laa,
+                        &mut s.account_base_app.write(),
                         td_height,
                     ) {
                         drop(laa);
@@ -437,8 +437,8 @@ pub fn end_block(
         let mut laa = la.get_committed_state().write();
         if let Some(tx) = staking::system_mint_pay(
             td_height,
-            &mut *laa,
-            &mut *s.account_base_app.write(),
+            &mut laa,
+            &mut s.account_base_app.write(),
         ) {
             drop(laa);
             // this unwrap should be safe
@@ -458,7 +458,7 @@ pub fn end_block(
     }
 
     staking::system_ops(
-        &mut *la.get_committed_state().write(),
+        &mut la.get_committed_state().write(),
         &header,
         begin_block_req.last_commit_info.as_ref(),
         &begin_block_req.byzantine_validators.as_slice(),

--- a/src/components/abciapp/src/api/query_server/query_api/ledger_api.rs
+++ b/src/components/abciapp/src/api/query_server/query_api/ledger_api.rs
@@ -87,7 +87,7 @@ pub async fn query_asset_issuance_num(
 ) -> actix_web::Result<web::Json<u64>> {
     let qs = data.read();
     let ledger = &qs.ledger_cloned;
-    if let Ok(token_code) = AssetTypeCode::new_from_base64(&*info) {
+    if let Ok(token_code) = AssetTypeCode::new_from_base64(&info) {
         if let Some(iss_num) = ledger.get_issuance_num(&token_code) {
             Ok(web::Json(iss_num))
         } else {
@@ -134,7 +134,7 @@ pub async fn query_asset(
 ) -> actix_web::Result<web::Json<AssetType>> {
     let qs = data.read();
     let ledger = &qs.ledger_cloned;
-    if let Ok(token_code) = AssetTypeCode::new_from_base64(&*info) {
+    if let Ok(token_code) = AssetTypeCode::new_from_base64(&info) {
         if let Some(asset) = ledger.get_asset_type(&token_code) {
             Ok(web::Json(asset))
         } else {

--- a/src/components/abciapp/src/api/query_server/query_api/mod.rs
+++ b/src/components/abciapp/src/api/query_server/query_api/mod.rs
@@ -307,7 +307,7 @@ pub async fn get_issued_records_by_code(
 ) -> actix_web::Result<web::Json<Vec<(TxOutput, Option<OwnerMemo>)>>> {
     let server = data.read();
 
-    match AssetTypeCode::new_from_base64(&*info).c(d!()) {
+    match AssetTypeCode::new_from_base64(&info).c(d!()) {
         Ok(token_code) => {
             if let Some(records) = server.get_issued_records_by_code(&token_code) {
                 Ok(web::Json(records))
@@ -516,7 +516,7 @@ pub async fn get_related_xfrs(
     info: web::Path<String>,
 ) -> actix_web::Result<web::Json<HashSet<TxnSID>>> {
     let server = data.read();
-    if let Ok(token_code) = AssetTypeCode::new_from_base64(&*info) {
+    if let Ok(token_code) = AssetTypeCode::new_from_base64(&info) {
         if let Some(records) = server.get_related_transfers(&token_code) {
             Ok(web::Json(records))
         } else {

--- a/src/components/contracts/baseapp/src/tm_events.rs
+++ b/src/components/contracts/baseapp/src/tm_events.rs
@@ -40,7 +40,7 @@ fn get_pending_hash() -> Result<Vec<H256>, attohttpc::Error> {
     );
     let mut pending_hash = vec![];
 
-    attohttpc::post(&url)
+    attohttpc::post(url)
         .header(attohttpc::header::CONTENT_TYPE, "application/json")
         .text(json)
         .send()
@@ -122,7 +122,7 @@ fn get_status() -> Result<bool, attohttpc::Error> {
     let json = String::from(
         "{\"jsonrpc\":\"2.0\",\"id\":\"anything\",\"method\":\"status\",\"params\":{}}",
     );
-    attohttpc::post(&url)
+    attohttpc::post(url)
         .header(attohttpc::header::CONTENT_TYPE, "application/json")
         .text(json)
         .send()

--- a/src/components/contracts/modules/account/Cargo.toml
+++ b/src/components/contracts/modules/account/Cargo.toml
@@ -30,4 +30,4 @@ parking_lot = "0.12"
 rand_chacha = "0.3"
 storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
 fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v1.0.0" }
-noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }

--- a/src/components/contracts/modules/ethereum/src/impls.rs
+++ b/src/components/contracts/modules/ethereum/src/impls.rs
@@ -72,7 +72,7 @@ impl<C: Config> App<C> {
 
         let pubkey = secp256k1_ecdsa_recover(&sig, &msg).ok()?;
         Some(H160::from(H256::from_slice(
-            Keccak256::digest(&pubkey).as_slice(),
+            Keccak256::digest(pubkey).as_slice(),
         )))
     }
 

--- a/src/components/contracts/modules/evm/Cargo.toml
+++ b/src/components/contracts/modules/evm/Cargo.toml
@@ -24,8 +24,8 @@ serde_json = "1.0.64"
 sha3 = { version = "0.10", default-features = false }
 hex = "0.4.2"
 ethabi = "17.1.0"
-noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 
 # primitives, don't depend on any modules
 fp-core = { path = "../../primitives/core" }

--- a/src/components/contracts/modules/evm/src/system_contracts.rs
+++ b/src/components/contracts/modules/evm/src/system_contracts.rs
@@ -31,7 +31,7 @@ impl SystemContracts {
             // Driect use this bytecode, beacuse we will remove on mainnet
             let bytecode_str = include_str!("../contracts/PrismXXProxy.bytecode");
 
-            let bytecode = hex::decode(&bytecode_str[2..].trim()).c(d!())?;
+            let bytecode = hex::decode(bytecode_str[2..].trim()).c(d!())?;
 
             let code_hash = keccak_256(&bytecode);
 

--- a/src/components/contracts/modules/evm/src/utils.rs
+++ b/src/components/contracts/modules/evm/src/utils.rs
@@ -17,7 +17,7 @@ pub fn deploy_contract<C: Config>(
     bytecode_str: &str,
 ) -> Result<()> {
     // Deploy Bridge here.
-    let bytecode = hex::decode(&bytecode_str[2..].trim()).c(d!())?;
+    let bytecode = hex::decode(bytecode_str[2..].trim()).c(d!())?;
 
     ActionRunner::<C>::inital_system_contract(
         ctx,
@@ -129,7 +129,7 @@ fn parse_truple_result(tuple: Vec<Token>) -> Result<NonConfidentialOutput> {
 
 pub fn compute_create2(caller: H160, salt: H256, code_hash: H256) -> H160 {
     let mut hasher = Keccak256::new();
-    hasher.update(&[0xff]);
+    hasher.update([0xff]);
     hasher.update(&caller[..]);
     hasher.update(&salt[..]);
     hasher.update(&code_hash[..]);

--- a/src/components/contracts/modules/evm/test-vector-support/src/lib.rs
+++ b/src/components/contracts/modules/evm/test-vector-support/src/lib.rs
@@ -37,7 +37,7 @@ pub fn test_precompile_test_vectors<P: Precompile>(
 ) -> std::result::Result<(), String> {
     use std::fs;
 
-    let data = fs::read_to_string(&filepath).expect("Failed to read blake2F.json");
+    let data = fs::read_to_string(filepath).expect("Failed to read blake2F.json");
 
     let tests: Vec<EthConsensusTest> =
         serde_json::from_str(&data).expect("expected json array");

--- a/src/components/contracts/modules/evm/tests/utils/solidity.rs
+++ b/src/components/contracts/modules/evm/tests/utils/solidity.rs
@@ -67,7 +67,7 @@ where
     let contract_arg =
         format!("/contracts/{}", contract_file.as_ref().to_str().unwrap());
     let output = Command::new("docker")
-        .args(&[
+        .args([
             "run",
             "-v",
             &source_mount_arg,

--- a/src/components/contracts/primitives/mocks/Cargo.toml
+++ b/src/components/contracts/primitives/mocks/Cargo.toml
@@ -18,7 +18,7 @@ rand_chacha = "0.3"
 rlp = "0.5"
 serde_json = "1.0"
 sha3 = "0.10"
-noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 
 # primitives
 fp-traits = { path = "../traits" }

--- a/src/components/contracts/primitives/types/Cargo.toml
+++ b/src/components/contracts/primitives/types/Cargo.toml
@@ -21,8 +21,8 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0"
 serde-big-array = "0.4"
 sha3 = "0.10"
-noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 
 # primitives
 fp-utils = { path = "../utils" }

--- a/src/components/contracts/primitives/types/src/crypto.rs
+++ b/src/components/contracts/primitives/types/src/crypto.rs
@@ -310,7 +310,7 @@ impl Verify for MultiSignature {
                 match secp256k1_ecdsa_recover(sig.as_ref(), &msg_hashed) {
                     Ok(pubkey) => {
                         Address32::from(H160::from(H256::from_slice(
-                            Keccak256::digest(&pubkey).as_slice(),
+                            Keccak256::digest(pubkey).as_slice(),
                         ))) == signer.clone()
                     }
                     _ => false,

--- a/src/components/contracts/primitives/utils/src/ecdsa.rs
+++ b/src/components/contracts/primitives/utils/src/ecdsa.rs
@@ -323,7 +323,7 @@ impl SecpPair {
             .map_err(|_| eg!("InvalidPhrase"))?;
         let bs = mnemonic.to_seed(password.unwrap_or(""));
         let ext = XPrv::derive_from_path(
-            &bs,
+            bs,
             &DerivationPath::from_str("m/44'/60'/0'/0/0")
                 .map_err(|_| eg!("InvalidDerivationPath"))?,
         )
@@ -360,7 +360,7 @@ impl SecpPair {
     pub fn address(&self) -> H160 {
         let mut res = [0u8; 64];
         res.copy_from_slice(&self.public.serialize()[1..65]);
-        H160::from(H256::from_slice(Keccak256::digest(&res).as_slice()))
+        H160::from(H256::from_slice(Keccak256::digest(res).as_slice()))
     }
 
     /// Sign a message.

--- a/src/components/contracts/primitives/wasm/src/wasm.rs
+++ b/src/components/contracts/primitives/wasm/src/wasm.rs
@@ -29,7 +29,7 @@ pub fn recover_signer(transaction: &Transaction) -> Option<H160> {
 
     let pubkey = secp256k1_ecdsa_recover(&sig, &msg).ok()?;
     Some(H160::from(H256::from_slice(
-        Keccak256::digest(&pubkey).as_slice(),
+        Keccak256::digest(pubkey).as_slice(),
     )))
 }
 

--- a/src/components/contracts/rpc/src/eth.rs
+++ b/src/components/contracts/rpc/src/eth.rs
@@ -1230,7 +1230,7 @@ fn transaction_build(
             {
                 match pubkey {
                     Some(pk) => {
-                        H160::from(H256::from_slice(Keccak256::digest(&pk).as_slice()))
+                        H160::from(H256::from_slice(Keccak256::digest(pk).as_slice()))
                     }
                     _ => H160::default(),
                 }
@@ -1406,11 +1406,11 @@ fn dummy_block(height: u64, full: bool) -> Rich<Block> {
     let hash = if height == *EVM_FIRST_BLOCK_HEIGHT - 1 {
         H256([0; 32])
     } else {
-        H256::from_slice(&sha3::Keccak256::digest(&height.to_le_bytes()))
+        H256::from_slice(&sha3::Keccak256::digest(height.to_le_bytes()))
     };
 
     let parent_hash =
-        H256::from_slice(&sha3::Keccak256::digest(&(height - 1).to_le_bytes()));
+        H256::from_slice(&sha3::Keccak256::digest((height - 1).to_le_bytes()));
 
     let transactions = if full {
         BlockTransactions::Full(vec![])

--- a/src/components/finutils/Cargo.toml
+++ b/src/components/finutils/Cargo.toml
@@ -25,9 +25,9 @@ tokio = "1.10.1"
 wasm-bindgen = { version = "0.2.50", features = ["serde-serialize"] }
 getrandom = "0.2"
 
-noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-crypto = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-crypto = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 
 ruc = "1.0"
 rucv3 = { package = "ruc", version = "3.0" }

--- a/src/components/wallet_mobile/Cargo.toml
+++ b/src/components/wallet_mobile/Cargo.toml
@@ -32,8 +32,8 @@ serde = { version = "1.0.124", features = ["derive"] }
 serde_derive = "^1.0.59"
 serde_json = "1.0"
 
-noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-algebra = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 
 finutils = { path = "../finutils", default-features = false, features = []}
 fp-types = { path = "../contracts/primitives/types" }

--- a/src/components/wasm/Cargo.toml
+++ b/src/components/wasm/Cargo.toml
@@ -36,9 +36,9 @@ ruc = "1.0"
 # OR the compiling will fail.
 getrandom = { version = "0.2", features = ["js"] }
 
-noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-crypto  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-crypto  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 
 finutils = { path = "../finutils", default-features = false }
 globutils = { path = "../../libs/globutils" }

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -34,10 +34,10 @@ fp-utils = { path = "../components/contracts/primitives/utils" }
 itertools = "0.10"
 ruc = "1.0"
 
-noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-crypto  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-bulletproofs = { git = "https://github.com/FindoraNetwork/bp", tag = "v1.0.1-f" }
+noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-crypto  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+bulletproofs = { git = "https://github.com/FindoraNetwork/bulletproofs", tag = "v1.0.1-f" }
 
 fbnc = { version = "0.2.9", default-features = false}
 
@@ -71,7 +71,7 @@ fs2 = "0.4"
 storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2", optional = true }
 fin_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2", optional = true }
 sparse_merkle_tree = { path = "../libs/sparse_merkle_tree" }
-noah-accumulators = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah-accumulators = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 
 [target.'cfg(target_arch = "wasm32")'.dependencies]
 parking_lot = { version = "0.11", features = ["wasm-bindgen"] }

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1769,7 +1769,7 @@ impl LedgerStatus {
         // Apply memo updates
         for (code, memo) in block.memo_updates.drain() {
             let mut asset = self.asset_types.get_mut(&code).unwrap();
-            (*asset).properties.memo = memo;
+            asset.properties.memo = memo;
         }
 
         for (code, amount) in block.issuance_amounts.drain() {

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1883,9 +1883,11 @@ fn build_mt_leaf_info_from_proof(proof: Proof, uid: u64) -> MTLeafInfo {
                 .nodes
                 .iter()
                 .map(|e| MTNode {
-                    siblings1: e.siblings1,
-                    siblings2: e.siblings2,
+                    left: e.left,
+                    mid: e.mid,
+                    right: e.right,
                     is_left_child: (e.path == TreePath::Left) as u8,
+                    is_mid_child: (e.path == TreePath::Middle) as u8,
                     is_right_child: (e.path == TreePath::Right) as u8,
                 })
                 .collect(),

--- a/src/libs/bitmap/src/test.rs
+++ b/src/libs/bitmap/src/test.rs
@@ -125,14 +125,14 @@ fn test_block() {
 #[test]
 fn test_basic_bitmap() {
     let path = "basic_bitmap";
-    let _ = fs::remove_file(&path);
+    let _ = fs::remove_file(path);
 
     // Create a new bitmap.
     let file = OpenOptions::new()
         .read(true)
         .write(true)
         .create_new(true)
-        .open(&path)
+        .open(path)
         .unwrap();
 
     let mut bitmap = BitMap::create(file).unwrap();
@@ -158,7 +158,7 @@ fn test_basic_bitmap() {
     let file = OpenOptions::new()
         .read(true)
         .write(true)
-        .open(&path)
+        .open(path)
         .unwrap();
 
     let mut bitmap = BitMap::open(file).unwrap();
@@ -297,7 +297,7 @@ fn test_basic_bitmap() {
     let file = OpenOptions::new()
         .read(true)
         .write(true)
-        .open(&path)
+        .open(path)
         .unwrap();
 
     let mut bitmap = BitMap::open(file).unwrap();
@@ -358,7 +358,7 @@ fn test_basic_bitmap() {
 
     drop(bitmap);
 
-    let _ = fs::remove_file(&path);
+    let _ = fs::remove_file(path);
 }
 
 #[test]

--- a/src/libs/credentials/Cargo.toml
+++ b/src/libs/credentials/Cargo.toml
@@ -12,4 +12,4 @@ linear-map = {version = "1.2.0", features = ["serde_impl"] }
 serde = "1.0.124"
 serde_derive = "1.0"
 wasm-bindgen = { version = "0.2.50", features = ["serde-serialize"]  }
-noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }

--- a/src/libs/globutils/Cargo.toml
+++ b/src/libs/globutils/Cargo.toml
@@ -12,9 +12,9 @@ serde_json = "1.0"
 time = "0.3"
 rand = "0.8"
 cryptohash = { path = "../cryptohash" }
-noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-crypto  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
-noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-crypto  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
+noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 hex = "0.4.2"
 bip32 = "0.3.0"
 

--- a/src/libs/globutils/src/wallet.rs
+++ b/src/libs/globutils/src/wallet.rs
@@ -89,7 +89,7 @@ fn restore_secp_keypair_from_mnemonic(
                 p.coin, p.account, p.change, p.address
             );
             bip32::XPrv::derive_from_path(
-                &seed,
+                seed,
                 &dp.parse::<bip32::DerivationPath>().c(d!())?,
             )
             .c(d!())

--- a/src/libs/sparse_merkle_tree/Cargo.toml
+++ b/src/libs/sparse_merkle_tree/Cargo.toml
@@ -25,7 +25,7 @@ serde_derive = "1.0"
 serde_json = "1.0"
 sha2 = "0.10"
 storage = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }
-noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.2.7" }
+noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 
 [dev-dependencies]
 temp_db = { git = "https://github.com/FindoraNetwork/storage.git", tag = "v0.2.2" }

--- a/src/libs/sparse_merkle_tree/src/lib.rs
+++ b/src/libs/sparse_merkle_tree/src/lib.rs
@@ -374,7 +374,7 @@ pub fn check_merkle_proof(
         };
     }
 
-    iter.next() == None && hash == *merkle_root
+    iter.next().is_none() && hash == *merkle_root
 }
 
 pub mod helpers {


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [ ] make test

* **The major changes of this PR**

The previous version of noah didn't use a tagged version of ark-bulletproofs-secq256k1, however, we plan to make changes to it. 

This PR fixes so for the develop branch. 

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

