### PR TITLE
Rollback wasm_bindgen version to 0.2.73

### DIFF
--- a/src/components/contracts/primitives/wasm/Cargo.toml
+++ b/src/components/contracts/primitives/wasm/Cargo.toml
@@ -22,7 +22,7 @@ rlp = "0.5"
 ruc = "1.0"
 sha3 = "0.10"
 serde_json = "1.0"
-wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"] }
 
 # Must enable the "js"-feature,
 # OR the compiling will fail.

--- a/src/components/finutils/Cargo.toml
+++ b/src/components/finutils/Cargo.toml
@@ -22,7 +22,7 @@ serde = { version = "1.0.124", features = ["derive"] }
 sha2 = "0.10"
 tokio = "1.10.1"
 
-wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"] }
 getrandom = "0.2"
 
 noah = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }

--- a/src/components/wallet_mobile/Cargo.toml
+++ b/src/components/wallet_mobile/Cargo.toml
@@ -60,7 +60,7 @@ features = [
 jni = "0.20"
 
 [target.'cfg(target_arch="wasm32")'.dependencies]
-wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"] }
 
 [target.'cfg(not(target_arch="wasm32"))'.dependencies]
 safer-ffi = "0.0.10"

--- a/src/components/wasm/Cargo.toml
+++ b/src/components/wasm/Cargo.toml
@@ -24,7 +24,7 @@ rand_chacha = "0.3"
 rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 serde = { version = "1.0.124", features = ["derive"] }
 serde_json = "1.0"
-wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"] }
 bs58 = "0.4"
 
 ring = "0.16.19"
@@ -71,7 +71,7 @@ features = [
 serde = "1.0.124"
 serde_json = "1.0.41"
 vergen = "=3.1.0"
-wasm-bindgen = { version = "0.2.83", features = ["serde-serialize"] }
+wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"] }
 
 [dev-dependencies]
 # Must enable the "js"-feature,

--- a/src/libs/credentials/Cargo.toml
+++ b/src/libs/credentials/Cargo.toml
@@ -11,6 +11,6 @@ rand_core = { version = "0.6", default-features = false, features = ["alloc"] }
 linear-map = {version = "1.2.0", features = ["serde_impl"] }
 serde = "1.0.124"
 serde_derive = "1.0"
-wasm-bindgen = { version = "0.2.50", features = ["serde-serialize"]  }
+wasm-bindgen = { version = "=0.2.73", features = ["serde-serialize"]  }
 noah  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.3.0" }
 


### PR DESCRIPTION
https://pullanswer.com/questions/import-__wbindgen_bigint_from_i64-with-non-js-compatible-func-sigurature-i64-as-parameter

* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**
The latest version of wasm_bindgen has a bug so we roll back.

* **The major impacts of this PR**
  - [x] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

