### PR TITLE
Use Rust optimization when compiling the instance for Nightly test

### DIFF
--- a/container/Dockerfile-binary-image-dev
+++ b/container/Dockerfile-binary-image-dev
@@ -19,7 +19,7 @@ RUN make lint
 RUN make test
 
 RUN mkdir -p /root/.cargo/bin/ && \
-    make build_release_debug && \
+    make build_release && \
     if [ -d /platform/release/bin ] ; then mv /platform/release/bin/* /binary/cleveldb ; rm -rf /platform/release/; else mv /platform/debug/bin/* /binary/cleveldb ; rm -rf /platform/debug/ ;fi
 
 CMD ["sleep", "999999"]


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [ ] make fmt
  - [ ] make lint
  - [ ] make test

* **The major changes of this PR**

A concern about the nightly test waiting time is that probably the nodes are too slow. This is possible because the nightly image uses a version of the platform library without Rust optimization.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

