### PR TITLE
Revert "Use Rust optimization when compiling the instance for Nightly test"

### DIFF
--- a/container/Dockerfile-binary-image-dev
+++ b/container/Dockerfile-binary-image-dev
@@ -19,7 +19,7 @@ RUN make lint
 RUN make test
 
 RUN mkdir -p /root/.cargo/bin/ && \
-    make build_release && \
+    make build_release_debug && \
     if [ -d /platform/release/bin ] ; then mv /platform/release/bin/* /binary/cleveldb ; rm -rf /platform/release/; else mv /platform/debug/bin/* /binary/cleveldb ; rm -rf /platform/debug/ ;fi
 
 CMD ["sleep", "999999"]


### PR DESCRIPTION
Reverts FindoraNetwork/platform#767

This causes an unpleasant effect on the checkpoint.toml that fails the transaction. In addition, it seems that the image is also compiled with `--release`, so this PR is unnecessary as well.