### PR TITLE
Fix the situation that the field pubkey_sign_map in the transaction structure will be out of order

### DIFF
--- a/src/components/abciapp/Cargo.toml
+++ b/src/components/abciapp/Cargo.toml
@@ -47,7 +47,7 @@ abci = { git = "https://github.com/FindoraNetwork/tendermint-abci", tag = "0.7.6
 config = { path = "../config"}
 ledger = { path = "../../ledger" }
 
-globutils = { git = "https://github.com/FindoraNetwork/platform-lib-utils", branch = "main" }
+globutils = { git = "https://github.com/FindoraNetwork/platform-lib-utils", rev = "1d9166312186cb16b86e66f62a0d1bbee44a3c2c" }
 cryptohash = { git = "https://github.com/FindoraNetwork/platform-lib-cryptohash", branch = "main" }
 
 finutils = { path = "../finutils" }

--- a/src/components/config/Cargo.toml
+++ b/src/components/config/Cargo.toml
@@ -16,7 +16,7 @@ serde_json = "1.0"
 serde-strz = "1.1.1"
 toml = "0.5.8"
 
-globutils = { git = "https://github.com/FindoraNetwork/platform-lib-utils", branch = "main" }
+globutils = { git = "https://github.com/FindoraNetwork/platform-lib-utils", rev = "1d9166312186cb16b86e66f62a0d1bbee44a3c2c" }
 
 [target.'cfg(target_os= "linux")'.dependencies]
 btm = "0.1.6"

--- a/src/components/config/src/abci/mod.rs
+++ b/src/components/config/src/abci/mod.rs
@@ -111,6 +111,11 @@ pub struct CheckPointConfig {
 
     #[serde(default = "def_remove_fake_staking_hash")]
     pub remove_fake_staking_hash: u64,
+
+    // Fix the situation that the field `pubkey_sign_map`
+    // in the transaction structure will be disordered after deserialization
+    #[serde(default = "def_fix_tx_sign_map_disorder")]
+    pub fix_tx_sign_map_disorder: i64,
 }
 
 fn def_check_signatures_num() -> i64 {
@@ -135,6 +140,10 @@ fn def_prism_bridge_address() -> String {
 
 fn def_remove_fake_staking_hash() -> u64 {
     DEFAULT_CHECKPOINT_CONFIG.remove_fake_staking_hash
+}
+
+fn def_fix_tx_sign_map_disorder() -> i64 {
+    DEFAULT_CHECKPOINT_CONFIG.fix_tx_sign_map_disorder
 }
 
 #[cfg(feature = "debug_env")]
@@ -168,6 +177,7 @@ lazy_static! {
         prismxx_inital_height: 128,
         prism_bridge_address: "0x5f9552fEd754F20B636C996DaDB32806554Bb995".to_owned(),
         remove_fake_staking_hash: 0,
+        fix_tx_sign_map_disorder: 0,
     };
 }
 
@@ -202,6 +212,7 @@ lazy_static! {
         prismxx_inital_height: 5000_0000,
         prism_bridge_address: String::new(),
         remove_fake_staking_hash: 5000_0000,
+        fix_tx_sign_map_disorder: 5000_0000,
     };
 }
 

--- a/src/components/finutils/Cargo.toml
+++ b/src/components/finutils/Cargo.toml
@@ -28,7 +28,7 @@ nix = "0.25"
 
 ledger = { path = "../../ledger" }
 
-globutils = { git = "https://github.com/FindoraNetwork/platform-lib-utils", branch = "main" }
+globutils = { git = "https://github.com/FindoraNetwork/platform-lib-utils", rev = "1d9166312186cb16b86e66f62a0d1bbee44a3c2c" }
 credentials = { git = "https://github.com/FindoraNetwork/platform-lib-credentials", branch = "main" }
 
 eth_checksum = { version = "0.1.2", optional = true }

--- a/src/components/wasm/Cargo.toml
+++ b/src/components/wasm/Cargo.toml
@@ -38,7 +38,7 @@ ruc = "1.0"
 
 finutils = { path = "../finutils", default-features = false }
 
-globutils = { git = "https://github.com/FindoraNetwork/platform-lib-utils", branch = "main" }
+globutils = { git = "https://github.com/FindoraNetwork/platform-lib-utils", rev = "1d9166312186cb16b86e66f62a0d1bbee44a3c2c" }
 credentials = { git = "https://github.com/FindoraNetwork/platform-lib-credentials", branch = "main" }
 cryptohash = { git = "https://github.com/FindoraNetwork/platform-lib-cryptohash", branch = "main" }
 

--- a/src/ledger/Cargo.toml
+++ b/src/ledger/Cargo.toml
@@ -37,7 +37,7 @@ fbnc = { version = "0.2.9", default-features = false}
 
 num-bigint = "0.4.3"
 
-globutils = { git = "https://github.com/FindoraNetwork/platform-lib-utils", branch = "main" }
+globutils = { git = "https://github.com/FindoraNetwork/platform-lib-utils", rev = "1d9166312186cb16b86e66f62a0d1bbee44a3c2c" }
 bitmap = { git = "https://github.com/FindoraNetwork/platform-lib-bitmap", branch = "main" }
 cryptohash = { git = "https://github.com/FindoraNetwork/platform-lib-cryptohash", branch = "main" }
 credentials = { git = "https://github.com/FindoraNetwork/platform-lib-credentials", branch = "main" }

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -16,8 +16,8 @@ use {
             AuthenticatedTransaction, AuthenticatedUtxo, AuthenticatedUtxoStatus,
             BlockEffect, BlockSID, FinalizedBlock, FinalizedTransaction, IssuerKeyPair,
             IssuerPublicKey, OutputPosition, StateCommitmentData, Transaction,
-            TransferType, TxnEffect, TxnSID, TxnTempSID, TxoSID, UnAuthenticatedUtxo,
-            Utxo, UtxoStatus, ASSET_TYPE_FRA, BLACK_HOLE_PUBKEY,
+            TransactionV1, TransferType, TxnEffect, TxnSID, TxnTempSID, TxoSID,
+            UnAuthenticatedUtxo, Utxo, UtxoStatus, ASSET_TYPE_FRA, BLACK_HOLE_PUBKEY,
         },
         staking::{
             Amount, Power, Staking, TendermintAddrRef, FF_PK_EXTRA_120_0000, FF_PK_LIST,
@@ -191,25 +191,32 @@ impl LedgerState {
         // Update the transaction Merkle tree
         // Store the location of each utxo so we can create authenticated utxo proofs
         let mut txn_merkle = self.txn_merkle.write();
-        for (tmp_sid, txn) in block.temp_sids.iter().zip(block.txns.iter()) {
+        for (tmp_sid, tx) in block.temp_sids.iter().zip(block.txns.iter()) {
             let txo_sid_map = tsm.get(&tmp_sid).c(d!())?;
             let txn_sid = txo_sid_map.0;
             let txo_sids = &txo_sid_map.1;
 
             let merkle_id = {
-                let mut txn = txn.clone();
+                let mut txn = tx.clone();
 
                 if (CFG.checkpoint.utxo_checktx_height as u64) > height {
                     txn.pubkey_sign_map = Default::default();
                 }
 
-                let hash = HashOf::new(&(txn_sid, txn)).0.hash;
+                // Rules to control hash based on checkpoint
+                let hash = if (CFG.checkpoint.fix_tx_sign_map_disorder as u64) > height {
+                    HashOf::new(&(txn_sid, txn))
+                } else {
+                    let tx_v1: TransactionV1 = tx.into();
+                    let json = serde_json::to_string(&(txn_sid, tx_v1)).c(d!())?;
+                    HashOf::new_from_str(json)
+                };
 
-                txn_merkle.append_hash(&hash.into()).c(d!())?
+                txn_merkle.append_hash(&hash.0.hash.into()).c(d!())?
             };
 
             tx_block.push(FinalizedTransaction {
-                txn: txn.clone(),
+                txn: tx.clone(),
                 tx_id: txn_sid,
                 txo_ids: txo_sids.clone(),
                 merkle_id,
@@ -317,9 +324,9 @@ impl LedgerState {
     //  1. Compute the hash of transactions in the block and update txns_in_block_hash
     //  2. Append txns_in_block_hash to block_merkle
     #[inline(always)]
-    fn compute_and_append_txns_hash(&mut self, block: &BlockEffect) -> u64 {
+    fn compute_and_append_txns_hash(&mut self, block: &BlockEffect) -> Result<u64> {
         // 1. Compute the hash of transactions in the block and update txns_in_block_hash
-        let txns_in_block_hash = block.compute_txns_in_block_hash();
+        let txns_in_block_hash = block.compute_txns_in_block_hash_v1().c(d!())?;
         self.status.txns_in_block_hash = Some(txns_in_block_hash.clone());
 
         // 2. Append txns_in_block_hash to block_merkle
@@ -330,7 +337,7 @@ impl LedgerState {
             .append_hash(&txns_in_block_hash.0.hash.into())
             .unwrap();
 
-        ret
+        Ok(ret)
     }
 
     fn compute_and_save_state_commitment_data(&mut self, pulse_count: u64) {
@@ -451,7 +458,7 @@ impl LedgerState {
 
     /// Perform checkpoint of current ledger state
     pub fn checkpoint(&mut self, block: &BlockEffect) -> Result<u64> {
-        let merkle_id = self.compute_and_append_txns_hash(&block);
+        let merkle_id = self.compute_and_append_txns_hash(&block).c(d!())?;
         let pulse_count = block
             .staking_simulator
             .cur_height()


### PR DESCRIPTION
New transaction structure body v1 version, the data structure of the field `pubkey_sign_map` is changed from `HashMap` to `BtreeMap`
```jsonc
pub struct TransactionV1 {
    pub body: TransactionBody,
    pub signatures: Vec<SignatureOf<TransactionBody>>,
    pub pubkey_sign_map: BTreeMap<XfrPublicKey, SignatureOf<TransactionBody>>,
}
```

The logic of the fix is as follows
1. create a new checkpoint `fix_tx_sign_map_disorder`
2. update `txn_merkle` when `update_state`, and use `TransactionV1` to replace the previous data structure to generate the hash when the checkpoint is reached
3. when updating `txns_in_block_hash`, when the checkpoint is reached, use the list constructed by `TransactionV1` to generate the hash instead of the previous data structure list
