### PR TITLE
Fix the issue where the value of fns_registry is incorrect under !debug_env.

### DIFF
--- a/src/components/config/src/abci/mod.rs
+++ b/src/components/config/src/abci/mod.rs
@@ -183,7 +183,7 @@ lazy_static! {
         prism_bridge_address: "0x5f9552fEd754F20B636C996DaDB32806554Bb995".to_owned(),
         remove_fake_staking_hash: 0,
         fix_check_replay: 0,
-        fns_registry: "0x57e8782c2f77B99823EeA48aCE3Eb7635F0B35F9".to_owned(),
+        fns_registry: "".to_owned(),
     };
 }
 
@@ -219,7 +219,7 @@ lazy_static! {
         prism_bridge_address: "0x4672372fDB139B7295Fc59b55b43EC5fF2761A0b".to_owned(),
         remove_fake_staking_hash: 4033522,
         fix_check_replay: 4033522,
-        fns_registry: "".to_owned(),
+        fns_registry: "0x57e8782c2f77B99823EeA48aCE3Eb7635F0B35F9".to_owned(),
     };
 }
 


### PR DESCRIPTION
The new field must delete the old checkpoint so that Findorad can generate it automatically to take effect. If you need to change this method, you need to re-code and load the rules for checkpoints. 
Currently, this PR only fixes the issue of incorrect `fns_registry` values ​​under `debug_env` and `!debug_env`.

