### PR TITLE
fix td block.header.lastResultsHash bug

### DIFF
--- a/src/components/contracts/modules/account/src/impls.rs
+++ b/src/components/contracts/modules/account/src/impls.rs
@@ -59,7 +59,6 @@ impl<C: Config> AccountAsset<Address> for App<C> {
         let mut from_account =
             Self::account_of(ctx, sender, None).c(d!("sender does not exist"))?;
         let mut to_account = Self::account_of(ctx, dest, None).unwrap_or_default();
-
         from_account.balance = from_account
             .balance
             .checked_sub(balance)


### PR DESCRIPTION
Fixing the error in abci due to inconsistent line numbers causing data and reson's data to be inconsistent with the entire network when reaching tendermint, resulting in an inconsistency in block.header.LastResultsHash.


before
```jsonc
{"Call":{"exit_reason":{"Error":{"Other":"SimpleError { msg: SimpleMsg { err: \"insufficient balance\", file: \"src/components/contracts/modules/account/src/impls.rs\", line: 65, column: 16 }, cause: None }"}},"value":[],"used_gas":"0xb8b1","logs":[]}}
```

after
```jsonc
{"Call":{"exit_reason":{"Error":{"Other":"SimpleError { msg: SimpleMsg { err: \"insufficient balance\", file: \"src/components/contracts/modules/account/src/impls.rs\", line: 66, column: 16 }, cause: None }"}},"value":[],"used_gas":"0xb8b1","logs":[]}}
```
