### PR TITLE
Let the Anemoi precompile use the platform-lib-noah library

### DIFF
--- a/src/components/contracts/modules/evm/precompile/anemoi/Cargo.toml
+++ b/src/components/contracts/modules/evm/precompile/anemoi/Cargo.toml
@@ -16,8 +16,7 @@ evm-precompile-utils = { path = "../utils"}
 tracing = "0.1"
 module-evm = { path = "../../../../modules/evm"}
 num_enum = { version = "0.5.4", default-features = false }
-noah-algebra  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.4.3" }
-noah-crypto  = { git = "https://github.com/FindoraNetwork/noah", tag = "v0.4.3" }
+platform-lib-noah = { git = "https://github.com/FindoraNetwork/platform-lib-noah", branch = "develop" }
 
 [dev-dependencies]
 baseapp = { path = "../../../../baseapp" }

--- a/src/components/contracts/modules/evm/precompile/anemoi/src/lib.rs
+++ b/src/components/contracts/modules/evm/precompile/anemoi/src/lib.rs
@@ -1,9 +1,9 @@
 use evm::executor::stack::{PrecompileFailure, PrecompileOutput};
 use evm::{Context, ExitError, ExitSucceed};
 use module_evm::precompile::{FinState, Precompile, PrecompileId, PrecompileResult};
-use noah_algebra::bls12_381::BLSScalar;
-use noah_algebra::prelude::Scalar;
-use noah_crypto::basic::anemoi_jive::{AnemoiJive, AnemoiJive381};
+use platform_lib_noah::noah_algebra::bls12_381::BLSScalar;
+use platform_lib_noah::noah_algebra::prelude::Scalar;
+use platform_lib_noah::noah_crypto::basic::anemoi_jive::{AnemoiJive, AnemoiJive381};
 
 /// The Anemoi precompile
 pub struct Anemoi;


### PR DESCRIPTION
* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**

Previously, the Anemoi precompile uses the Noah library directly. For unified version control, in this PR, we change to use platform-lib-noah only.

* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

