### PR TITLE
Fix failure for DefineAsset and IssueAsset operation sent in same txn

### DIFF
--- a/src/components/abciapp/src/abci/server/callback/mod.rs
+++ b/src/components/abciapp/src/abci/server/callback/mod.rs
@@ -507,6 +507,7 @@ pub fn deliver_tx(
 }
 
 /// putting block in the ledgerState
+#[allow(noop_method_call)]
 pub fn end_block(
     s: &mut ABCISubmissionServer,
     req: &RequestEndBlock,

--- a/src/components/abciapp/src/abci/staking/mod.rs
+++ b/src/components/abciapp/src/abci/staking/mod.rs
@@ -234,6 +234,7 @@ pub fn get_validators(
 /// - pay delegation rewards
 /// - pay proposer rewards(traditional block rewards)
 /// - do governance operations
+#[allow(noop_method_call)]
 pub fn system_ops(
     la: &mut LedgerState,
     header: &Header,

--- a/src/components/finutils/src/bins/fn.yml
+++ b/src/components/finutils/src/bins/fn.yml
@@ -158,7 +158,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `staker-priv-key` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - staker-priv-key
   - claim:
       about: Claim accumulated FRA rewards
@@ -183,7 +183,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - seckey
   - delegate:
       about: Delegating operations
@@ -213,7 +213,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - seckey
   - undelegate:
       about: Undelegating operations
@@ -237,7 +237,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - seckey
   - transfer:
       about: Transfer tokens from one address to another
@@ -285,7 +285,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `from-seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - from-seckey
   - transfer-batch:
       about: Transfer tokens from one address to many others
@@ -324,7 +324,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `from-seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - from-seckey
   - wallet:
       about: manipulates a findora wallet
@@ -355,14 +355,14 @@ subcommands:
         - gen-eth-address:
             help: generate the keypair of an eth address
             long: gen-eth-address
-            conflicts-with:
+            conflicts_with:
               - show
               - seckey
               - asset
         - use-default-eth-address:
             help: use a private key of the eth address if `seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - seckey
               - create
   - asset:
@@ -466,7 +466,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - seckey
   - account:
       about: Return user contract account information or the balance if secret key is provided
@@ -492,7 +492,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `sec-key` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - sec-key
   - contract-deposit:
       about: Transfer an asset from the UTXO chain to the EVM chain
@@ -582,7 +582,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `from-seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - from-seckey
   - anon-balance:
       about: List Anon balance and spending status for a public key and a list of commitments
@@ -611,7 +611,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `from-seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - from-seckey
   - owned-open-abars:
       about: Get Open Anon UTXOs for a keypair using commitment
@@ -634,7 +634,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `from-seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - from-seckey
   - owned-utxos:
       about: List owned UTXOs for a public key
@@ -674,7 +674,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `from-seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - from-seckey
   - convert-abar-to-bar:
       about: Convert an ABAR to BAR
@@ -717,7 +717,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `from-seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - from-seckey
   - anon-transfer:
       about: Perform an anonymous transfer
@@ -759,7 +759,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `from-seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - from-seckey
   - anon-transfer-batch:
       about: Anonymous Transfer of tokens from multiple inputs to multiple outputs
@@ -801,7 +801,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `from-seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - from-seckey
   - anon-fetch-merkle-proof:
       about: Query Merkle tree leaf info
@@ -834,7 +834,7 @@ subcommands:
         - use-default-eth-address:
             help: use a private key of the eth address if `from-seckey` is not provided
             long: use-default-eth-address
-            conflicts-with:
+            conflicts_with:
               - from-seckey
   - replace_staker:
       about: Replace the staker of the validator with target address

--- a/src/ledger/src/data_model/effects.rs
+++ b/src/ledger/src/data_model/effects.rs
@@ -287,7 +287,7 @@ impl TxnEffect {
 
         // (1), within this transaction
         //let v = vec![];
-        let iss_nums = self.new_issuance_nums.entry(code).or_insert_with(Vec::new);
+        let iss_nums = self.new_issuance_nums.entry(code).or_default();
 
         if let Some(last_num) = iss_nums.last() {
             if seq_num <= *last_num {

--- a/src/ledger/src/staking/mod.rs
+++ b/src/ledger/src/staking/mod.rs
@@ -809,7 +809,7 @@ impl Staking {
         self.delegation_info
             .end_height_map
             .entry(end_height)
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(owner);
 
         // There should be no failure here !!
@@ -903,7 +903,7 @@ impl Staking {
             self.delegation_info
                 .end_height_map
                 .entry(h + CFG.checkpoint.unbond_block_cnt)
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .insert(*addr);
         }
 
@@ -995,7 +995,7 @@ impl Staking {
         self.delegation_info
             .end_height_map
             .entry(h + CFG.checkpoint.unbond_block_cnt)
-            .or_insert_with(BTreeSet::new)
+            .or_default()
             .insert(pu.new_delegator_id);
 
         // update delegator entries for pu target_validator
@@ -1078,7 +1078,7 @@ impl Staking {
             self.delegation_info
                 .end_height_map
                 .entry(end_height)
-                .or_insert_with(BTreeSet::new)
+                .or_default()
                 .insert(addr.to_owned());
             Ok(())
         } else {

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1730,7 +1730,7 @@ impl LedgerStatus {
     //
     // This drains every field of `block` except `txns` and `temp_sids`.
     #[allow(unused_mut)]
-    #[allow(clippy::unwrap_or_else_default)]
+    #[allow(clippy::unwrap_or_default)]
     fn apply_block_effects(&mut self, block: &mut BlockEffect) -> (TmpSidMap, u64, u64) {
         let base_sid = self.next_txo.0;
         let handle_asset_type_code = |code: AssetTypeCode| {

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1562,7 +1562,6 @@ impl LedgerStatus {
                 }
                 None
             };
-
         
         // New issuance numbers
         // (1) Must refer to a created asset type

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1730,6 +1730,7 @@ impl LedgerStatus {
     //
     // This drains every field of `block` except `txns` and `temp_sids`.
     #[allow(unused_mut)]
+    #[allow(clippy::unwrap_or_default)]
     fn apply_block_effects(&mut self, block: &mut BlockEffect) -> (TmpSidMap, u64, u64) {
         let base_sid = self.next_txo.0;
         let handle_asset_type_code = |code: AssetTypeCode| {

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1547,6 +1547,20 @@ impl LedgerStatus {
             // Asset issuance should match the currently registered key
         }
 
+        let get_effect_asset = |derived_asset_code: &AssetTypeCode| -> Option<AssetType> {
+            for (code, asset) in &txn_effect.new_asset_codes {
+                let dc = AssetTypeCode::from_prefix_and_raw_asset_type_code(
+                    AssetTypePrefix::UserDefined,
+                    &code,
+                    &CFG.checkpoint,
+                    self.td_commit_height,
+                );
+                if dc == *derived_asset_code {
+                    return Some(asset.clone())
+                }
+            }
+            return None
+        };
         // New issuance numbers
         // (1) Must refer to a created asset type
         //  - NOTE: if the asset type is created in this transaction, this
@@ -1560,7 +1574,7 @@ impl LedgerStatus {
             let asset_type = self
                 .asset_types
                 .get(&code)
-                .or_else(|| txn_effect.new_asset_codes.get(&code).cloned())
+                .or_else(|| get_effect_asset(&code))
                 .c(d!())?;
             let proper_key = asset_type.properties.issuer;
             if *iss_key != proper_key {

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1563,6 +1563,7 @@ impl LedgerStatus {
         //        None
         //    };
 
+        
         // New issuance numbers
         // (1) Must refer to a created asset type
         //  - NOTE: if the asset type is created in this transaction, this

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1730,7 +1730,7 @@ impl LedgerStatus {
     //
     // This drains every field of `block` except `txns` and `temp_sids`.
     #[allow(unused_mut)]
-    #[allow(clippy::unwrap_or_default)]
+    #[allow(clippy::unwrap_or_else_default)]
     fn apply_block_effects(&mut self, block: &mut BlockEffect) -> (TmpSidMap, u64, u64) {
         let base_sid = self.next_txo.0;
         let handle_asset_type_code = |code: AssetTypeCode| {

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1547,21 +1547,21 @@ impl LedgerStatus {
             // Asset issuance should match the currently registered key
         }
 
-        //let get_effect_asset =
-        //    |derived_asset_code: &AssetTypeCode| -> Option<AssetType> {
-        //        for (code, asset) in &txn_effect.new_asset_codes {
-        //            let dc = AssetTypeCode::from_prefix_and_raw_asset_type_code(
-        //                AssetTypePrefix::UserDefined,
-        //                &code,
-        //                &CFG.checkpoint,
-        //                self.td_commit_height,
-        //            );
-        //            if dc == *derived_asset_code {
-        //                return Some(asset.clone());
-        //            }
-        //        }
-        //        None
-        //    };
+        let get_effect_asset =
+            |derived_asset_code: &AssetTypeCode| -> Option<AssetType> {
+                for (code, asset) in &txn_effect.new_asset_codes {
+                    let dc = AssetTypeCode::from_prefix_and_raw_asset_type_code(
+                        AssetTypePrefix::UserDefined,
+                        &code,
+                        &CFG.checkpoint,
+                        self.td_commit_height,
+                    );
+                    if dc == *derived_asset_code {
+                        return Some(asset.clone());
+                    }
+                }
+                None
+            };
 
         
         // New issuance numbers
@@ -1577,7 +1577,7 @@ impl LedgerStatus {
             let asset_type = self
                 .asset_types
                 .get(&code)
-                .or_else(|| txn_effect.new_asset_codes.get(&code).cloned())
+                .or_else(|| get_effect_asset(&code))
                 .c(d!())?;
             let proper_key = asset_type.properties.issuer;
             if *iss_key != proper_key {

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1547,20 +1547,21 @@ impl LedgerStatus {
             // Asset issuance should match the currently registered key
         }
 
-        let get_effect_asset = |derived_asset_code: &AssetTypeCode| -> Option<AssetType> {
-            for (code, asset) in &txn_effect.new_asset_codes {
-                let dc = AssetTypeCode::from_prefix_and_raw_asset_type_code(
-                    AssetTypePrefix::UserDefined,
-                    &code,
-                    &CFG.checkpoint,
-                    self.td_commit_height,
-                );
-                if dc == *derived_asset_code {
-                    return Some(asset.clone())
+        let get_effect_asset =
+            |derived_asset_code: &AssetTypeCode| -> Option<AssetType> {
+                for (code, asset) in &txn_effect.new_asset_codes {
+                    let dc = AssetTypeCode::from_prefix_and_raw_asset_type_code(
+                        AssetTypePrefix::UserDefined,
+                        &code,
+                        &CFG.checkpoint,
+                        self.td_commit_height,
+                    );
+                    if dc == *derived_asset_code {
+                        return Some(asset.clone());
+                    }
                 }
-            }
-            return None
-        };
+                None
+            };
         // New issuance numbers
         // (1) Must refer to a created asset type
         //  - NOTE: if the asset type is created in this transaction, this

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1562,6 +1562,7 @@ impl LedgerStatus {
         //        }
         //        None
         //    };
+
         // New issuance numbers
         // (1) Must refer to a created asset type
         //  - NOTE: if the asset type is created in this transaction, this

--- a/src/ledger/src/store/mod.rs
+++ b/src/ledger/src/store/mod.rs
@@ -1547,21 +1547,21 @@ impl LedgerStatus {
             // Asset issuance should match the currently registered key
         }
 
-        let get_effect_asset =
-            |derived_asset_code: &AssetTypeCode| -> Option<AssetType> {
-                for (code, asset) in &txn_effect.new_asset_codes {
-                    let dc = AssetTypeCode::from_prefix_and_raw_asset_type_code(
-                        AssetTypePrefix::UserDefined,
-                        &code,
-                        &CFG.checkpoint,
-                        self.td_commit_height,
-                    );
-                    if dc == *derived_asset_code {
-                        return Some(asset.clone());
-                    }
-                }
-                None
-            };
+        //let get_effect_asset =
+        //    |derived_asset_code: &AssetTypeCode| -> Option<AssetType> {
+        //        for (code, asset) in &txn_effect.new_asset_codes {
+        //            let dc = AssetTypeCode::from_prefix_and_raw_asset_type_code(
+        //                AssetTypePrefix::UserDefined,
+        //                &code,
+        //                &CFG.checkpoint,
+        //                self.td_commit_height,
+        //            );
+        //            if dc == *derived_asset_code {
+        //                return Some(asset.clone());
+        //            }
+        //        }
+        //        None
+        //    };
         // New issuance numbers
         // (1) Must refer to a created asset type
         //  - NOTE: if the asset type is created in this transaction, this
@@ -1575,7 +1575,7 @@ impl LedgerStatus {
             let asset_type = self
                 .asset_types
                 .get(&code)
-                .or_else(|| get_effect_asset(&code))
+                .or_else(|| txn_effect.new_asset_codes.get(&code).cloned())
                 .c(d!())?;
             let proper_key = asset_type.properties.issuer;
             if *iss_key != proper_key {


### PR DESCRIPTION
The DefineAsset Operation has the raw asset code whereas IssueAsset Operation has the derived asset code.

Currently if both the operations are sent in the same txn for a new asset it fails because the Asset code don't match. This is fixed by comparing the derived asset code from newly defined assets in the txn.

* **make sure that you have executed all the following process and no errors occur**
  - [x] make fmt
  - [x] make lint
  - [x] make test

* **The major changes of this PR**


* **The major impacts of this PR**
  - [ ] Impact WASM?
  - [ ] Impact Web3 API?
  - [ ] Impact mainnet data compatibility?

* **Extra documentations**

